### PR TITLE
Feat/#20 그룹 삭제 및 탈퇴 구현

### DIFF
--- a/src/main/java/com/awp/mgw/activity/port/ActivityGroupRepository.java
+++ b/src/main/java/com/awp/mgw/activity/port/ActivityGroupRepository.java
@@ -1,0 +1,9 @@
+package com.awp.mgw.activity.port;
+
+import com.awp.mgw.activity.domain.ActivityGroup;
+import com.awp.mgw.group.domain.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityGroupRepository extends JpaRepository<ActivityGroup, Long> {
+    void deleteAllByGroup(Group group);
+}

--- a/src/main/java/com/awp/mgw/group/controller/GroupController.java
+++ b/src/main/java/com/awp/mgw/group/controller/GroupController.java
@@ -5,9 +5,13 @@ import com.awp.mgw.group.controller.dto.response.CreateGroupResponse;
 import com.awp.mgw.group.controller.dto.response.GetGroupDetailResponse;
 import com.awp.mgw.group.controller.dto.response.GetGroupListResponse;
 import com.awp.mgw.group.usecase.command.CreateGroupUseCase;
+import com.awp.mgw.group.usecase.command.DeleteGroupUseCase;
+import com.awp.mgw.group.usecase.command.LeaveGroupUseCase;
 import com.awp.mgw.group.usecase.command.UpdateGroupUseCase;
 import com.awp.mgw.group.usecase.query.GetGroupDetailUseCase;
 import com.awp.mgw.group.usecase.query.GetGroupListUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,11 +30,18 @@ public class GroupController {
 
     private final CreateGroupUseCase createGroupUseCase;
     private final UpdateGroupUseCase updateGroupUseCase;
+    private final DeleteGroupUseCase deleteGroupUseCase;
+    private final LeaveGroupUseCase leaveGroupUseCase;
     private final GetGroupListUseCase getGroupListUseCase;
     private final GetGroupDetailUseCase getGroupDetailUseCase;
 
     @PostMapping
+    @Operation(
+            summary = "그룹 생성",
+            description = "회원이 그룹 모집글을 생성합니다. 생성자는 그룹 작성자이자 최초 그룹 멤버로 등록됩니다."
+    )
     public CreateGroupResponse createGroup(
+        @Parameter(description = "그룹을 생성하는 회원 ID", example = "1")
         @RequestParam Long memberId,
         @Valid @RequestBody CreateGroupRequest request
     ) {
@@ -38,8 +49,14 @@ public class GroupController {
     }
 
     @PutMapping("/{groupId}")
+    @Operation(
+            summary = "그룹 수정",
+            description = "그룹 작성자만 그룹 모집글을 수정할 수 있습니다."
+    )
     public CreateGroupResponse updateGroup(
+        @Parameter(description = "수정 요청 회원 ID", example = "1")
         @RequestParam Long memberId,
+        @Parameter(description = "수정할 그룹 ID", example = "10")
         @PathVariable Long groupId,
         @Valid @RequestBody CreateGroupRequest request
     ) {
@@ -47,20 +64,61 @@ public class GroupController {
     }
 
     @GetMapping
+    @Operation(
+            summary = "그룹 목록 조회",
+            description = "공개 그룹과 본인이 작성한 비공개 그룹을 조회합니다. categoryIds가 없으면 전체 조회하며, 정렬은 createdAt, updatedAt, name, title, capacity, id를 지원합니다."
+    )
     public GetGroupListResponse getGroupList(
+            @Parameter(description = "조회 요청 회원 ID", example = "1")
             @RequestParam Long memberId,
             // 값이 없으면 전체 그룹 조회, 값이 있으면 해당 카테고리에 속한 그룹만 조회
+            @Parameter(description = "필터링할 카테고리 ID 목록. 없으면 전체 조회", example = "1")
             @RequestParam(required = false) List<Long> categoryIds,
+            @Parameter(description = "페이징 및 정렬 정보. 예: sort=createdAt,desc / sort=name,asc / sort=capacity,desc")
             @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return getGroupListUseCase.getGroupList(memberId, categoryIds, pageable);
     }
 
     @GetMapping("/{groupId}")
+    @Operation(
+            summary = "그룹 상세 조회",
+            description = "공개 그룹 또는 본인이 작성한 비공개 그룹을 상세 조회합니다. 그룹 정보, 현재 인원 수, 댓글 목록을 함께 반환합니다."
+    )
     public GetGroupDetailResponse getGroupDetail(
+            @Parameter(description = "조회 요청 회원 ID", example = "1")
             @RequestParam Long memberId,
+            @Parameter(description = "조회할 그룹 ID", example = "10")
             @PathVariable Long groupId
     ) {
         return getGroupDetailUseCase.getGroupDetail(memberId, groupId);
+    }
+
+    @DeleteMapping("/{groupId}")
+    @Operation(
+            summary = "그룹 삭제",
+            description = "그룹 작성자만 삭제할 수 있습니다. 삭제 시 그룹 댓글, 그룹 멤버, 그룹 카테고리, 활동-그룹 매핑이 함께 제거됩니다."
+    )
+    public void deleteGroup(
+            @Parameter(description = "삭제 요청 회원 ID", example = "1")
+            @RequestParam Long memberId,
+            @Parameter(description = "삭제할 그룹 ID", example = "10")
+            @PathVariable Long groupId
+    ) {
+        deleteGroupUseCase.deleteGroup(memberId, groupId);
+    }
+
+    @DeleteMapping("/{groupId}/members/me")
+    @Operation(
+            summary = "그룹 탈퇴",
+            description = "그룹 멤버만 탈퇴할 수 있습니다. 그룹 작성자는 다른 팀원이 모두 나가고 혼자 남았을 때만 탈퇴할 수 있습니다."
+    )
+    public void leaveGroup(
+            @Parameter(description = "탈퇴 요청 회원 ID", example = "1")
+            @RequestParam Long memberId,
+            @Parameter(description = "탈퇴할 그룹 ID", example = "10")
+            @PathVariable Long groupId
+    ) {
+        leaveGroupUseCase.leaveGroup(memberId, groupId);
     }
 }

--- a/src/main/java/com/awp/mgw/group/domain/exception/GroupErrorCode.java
+++ b/src/main/java/com/awp/mgw/group/domain/exception/GroupErrorCode.java
@@ -26,6 +26,7 @@ public enum GroupErrorCode implements BaseCode {
     COMMENT_NOT_OWNED(HttpStatus.FORBIDDEN, "GROUP-013", "본인의 댓글만 수정/삭제할 수 있습니다."),
     INVALID_COMMENT_CONTENT(HttpStatus.BAD_REQUEST, "GROUP-014", "댓글 내용이 유효하지 않습니다."),
     INVALID_COMMENT_PARENT(HttpStatus.BAD_REQUEST, "GROUP-015", "부모 댓글 정보가 유효하지 않습니다."),
+    GROUP_OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "GROUP-016", "그룹 작성자는 팀원이 남아있으면 탈퇴할 수 없습니다."),
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/awp/mgw/group/port/GroupMemberRepository.java
+++ b/src/main/java/com/awp/mgw/group/port/GroupMemberRepository.java
@@ -3,5 +3,10 @@ package com.awp.mgw.group.port;
 import com.awp.mgw.group.domain.GroupMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+    Optional<GroupMember> findByMember_IdAndGroup_Id(Long memberId, Long groupId);
+
+    long countByGroup_Id(Long groupId);
 }

--- a/src/main/java/com/awp/mgw/group/service/GroupCommandService.java
+++ b/src/main/java/com/awp/mgw/group/service/GroupCommandService.java
@@ -1,5 +1,6 @@
 package com.awp.mgw.group.service;
 
+import com.awp.mgw.activity.port.ActivityGroupRepository;
 import com.awp.mgw.category.domain.Category;
 import com.awp.mgw.category.domain.exception.CategoryDomainException;
 import com.awp.mgw.category.domain.exception.CategoryErrorCode;
@@ -15,6 +16,8 @@ import com.awp.mgw.group.port.GroupCategoryRepository;
 import com.awp.mgw.group.port.GroupMemberRepository;
 import com.awp.mgw.group.port.GroupRepository;
 import com.awp.mgw.group.usecase.command.CreateGroupUseCase;
+import com.awp.mgw.group.usecase.command.DeleteGroupUseCase;
+import com.awp.mgw.group.usecase.command.LeaveGroupUseCase;
 import com.awp.mgw.group.usecase.command.UpdateGroupUseCase;
 import com.awp.mgw.member.domain.Member;
 import com.awp.mgw.member.domain.exception.MemberDomainException;
@@ -29,11 +32,12 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class GroupCommandService implements CreateGroupUseCase, UpdateGroupUseCase {
+public class GroupCommandService implements CreateGroupUseCase, UpdateGroupUseCase, DeleteGroupUseCase, LeaveGroupUseCase {
 
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final GroupCategoryRepository groupCategoryRepository;
+    private final ActivityGroupRepository activityGroupRepository;
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
 
@@ -90,6 +94,32 @@ public class GroupCommandService implements CreateGroupUseCase, UpdateGroupUseCa
         return CreateGroupResponse.from(group.getId());
     }
 
+    @Override
+    public void deleteGroup(Long memberId, Long groupId) {
+        Member member = getMemberOrThrow(memberId);
+        Group group = getOwnedGroupOrThrow(groupId, member.getId());
+
+        // Group 내부 연관(comment, groupMember, groupCategory)은 cascade로 삭제되고,
+        // ActivityGroup은 Group의 cascade 범위 밖이라 먼저 제거한다.
+        activityGroupRepository.deleteAllByGroup(group);
+        groupRepository.delete(group);
+    }
+
+    @Override
+    public void leaveGroup(Long memberId, Long groupId) {
+        Member member = getMemberOrThrow(memberId);
+        Group group = getGroupOrThrow(groupId);
+        GroupMember groupMember = groupMemberRepository.findByMember_IdAndGroup_Id(member.getId(), group.getId())
+                .orElseThrow(() -> new GroupDomainException(GroupErrorCode.GROUP_MEMBER_NOT_FOUND));
+
+        if (isGroupOwner(group, member.getId())) {
+            validateOwnerCanLeave(group);
+            group.detachMember();
+        }
+
+        groupMemberRepository.delete(groupMember);
+    }
+
     /**
      * 그룹 정원 유효성 검증
      */
@@ -108,14 +138,30 @@ public class GroupCommandService implements CreateGroupUseCase, UpdateGroupUseCa
     }
 
     private Group getOwnedGroupOrThrow(Long groupId, Long memberId) {
-        Group group = groupRepository.findById(groupId)
-            .orElseThrow(() -> new GroupDomainException(GroupErrorCode.GROUP_NOT_FOUND));
+        Group group = getGroupOrThrow(groupId);
 
-        if (group.getMember() == null || !group.getMember().getId().equals(memberId)) {
+        if (!isGroupOwner(group, memberId)) {
             throw new GroupDomainException(GroupErrorCode.GROUP_NOT_OWNED);
         }
 
         return group;
+    }
+
+    private Group getGroupOrThrow(Long groupId) {
+        return groupRepository.findById(groupId)
+            .orElseThrow(() -> new GroupDomainException(GroupErrorCode.GROUP_NOT_FOUND));
+    }
+
+    private boolean isGroupOwner(Group group, Long memberId) {
+        return group.getMember() != null && group.getMember().getId().equals(memberId);
+    }
+
+    private void validateOwnerCanLeave(Group group) {
+        long currentMemberCount = groupMemberRepository.countByGroup_Id(group.getId());
+
+        if (currentMemberCount > 1) {
+            throw new GroupDomainException(GroupErrorCode.GROUP_OWNER_CANNOT_LEAVE);
+        }
     }
 
     private List<Category> getCategoriesOrThrow(List<Long> categoryIds) {

--- a/src/main/java/com/awp/mgw/group/usecase/command/DeleteGroupUseCase.java
+++ b/src/main/java/com/awp/mgw/group/usecase/command/DeleteGroupUseCase.java
@@ -1,0 +1,5 @@
+package com.awp.mgw.group.usecase.command;
+
+public interface DeleteGroupUseCase {
+    void deleteGroup(Long memberId, Long groupId);
+}

--- a/src/main/java/com/awp/mgw/group/usecase/command/LeaveGroupUseCase.java
+++ b/src/main/java/com/awp/mgw/group/usecase/command/LeaveGroupUseCase.java
@@ -1,0 +1,5 @@
+package com.awp.mgw.group.usecase.command;
+
+public interface LeaveGroupUseCase {
+    void leaveGroup(Long memberId, Long groupId);
+}

--- a/src/test/java/com/awp/mgw/MgwApplicationTests.java
+++ b/src/test/java/com/awp/mgw/MgwApplicationTests.java
@@ -1,13 +1,14 @@
 package com.awp.mgw;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+import static org.assertj.core.api.Assertions.assertThat;
+
 class MgwApplicationTests {
 
 	@Test
 	void contextLoads() {
+		assertThat(MgwApplication.class).isNotNull();
 	}
 
 }

--- a/src/test/java/com/awp/mgw/group/service/GroupCommandServiceTest.java
+++ b/src/test/java/com/awp/mgw/group/service/GroupCommandServiceTest.java
@@ -1,0 +1,160 @@
+package com.awp.mgw.group.service;
+
+import com.awp.mgw.activity.port.ActivityGroupRepository;
+import com.awp.mgw.category.port.CategoryRepository;
+import com.awp.mgw.group.domain.Group;
+import com.awp.mgw.group.domain.GroupMember;
+import com.awp.mgw.group.domain.exception.GroupDomainException;
+import com.awp.mgw.group.domain.exception.GroupErrorCode;
+import com.awp.mgw.group.port.GroupCategoryRepository;
+import com.awp.mgw.group.port.GroupMemberRepository;
+import com.awp.mgw.group.port.GroupRepository;
+import com.awp.mgw.member.domain.Member;
+import com.awp.mgw.member.port.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GroupCommandServiceTest {
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+
+    @Mock
+    private GroupCategoryRepository groupCategoryRepository;
+
+    @Mock
+    private ActivityGroupRepository activityGroupRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private GroupCommandService groupCommandService;
+
+    @Test
+    void deleteGroupDeletesOnlyWhenRequesterIsOwner() {
+        Member owner = member(1L);
+        Group group = group(10L, owner);
+        when(memberRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+        when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+        groupCommandService.deleteGroup(owner.getId(), group.getId());
+
+        verify(activityGroupRepository).deleteAllByGroup(group);
+        verify(groupRepository).delete(group);
+    }
+
+    @Test
+    void deleteGroupThrowsWhenRequesterIsNotOwner() {
+        Member owner = member(1L);
+        Member requester = member(2L);
+        Group group = group(10L, owner);
+        when(memberRepository.findById(requester.getId())).thenReturn(Optional.of(requester));
+        when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+
+        assertThatThrownBy(() -> groupCommandService.deleteGroup(requester.getId(), group.getId()))
+                .isInstanceOf(GroupDomainException.class)
+                .hasMessage(GroupErrorCode.GROUP_NOT_OWNED.getMessage());
+
+        verify(activityGroupRepository, never()).deleteAllByGroup(group);
+        verify(groupRepository, never()).delete(group);
+    }
+
+    @Test
+    void leaveGroupDeletesMembershipWhenRequesterIsNormalMember() {
+        Member owner = member(1L);
+        Member requester = member(2L);
+        Group group = group(10L, owner);
+        GroupMember groupMember = GroupMember.create(requester, group);
+        when(memberRepository.findById(requester.getId())).thenReturn(Optional.of(requester));
+        when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+        when(groupMemberRepository.findByMember_IdAndGroup_Id(requester.getId(), group.getId()))
+                .thenReturn(Optional.of(groupMember));
+
+        groupCommandService.leaveGroup(requester.getId(), group.getId());
+
+        verify(groupMemberRepository).delete(groupMember);
+        assertThat(group.getMember()).isEqualTo(owner);
+    }
+
+    @Test
+    void leaveGroupThrowsWhenOwnerLeavesBeforeOtherMembers() {
+        Member owner = member(1L);
+        Group group = group(10L, owner);
+        GroupMember groupMember = GroupMember.create(owner, group);
+        when(memberRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+        when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+        when(groupMemberRepository.findByMember_IdAndGroup_Id(owner.getId(), group.getId()))
+                .thenReturn(Optional.of(groupMember));
+        when(groupMemberRepository.countByGroup_Id(group.getId())).thenReturn(2L);
+
+        assertThatThrownBy(() -> groupCommandService.leaveGroup(owner.getId(), group.getId()))
+                .isInstanceOf(GroupDomainException.class)
+                .hasMessage(GroupErrorCode.GROUP_OWNER_CANNOT_LEAVE.getMessage());
+
+        verify(groupMemberRepository, never()).delete(groupMember);
+        assertThat(group.getMember()).isEqualTo(owner);
+    }
+
+    @Test
+    void leaveGroupAllowsOwnerWhenOwnerIsLastMember() {
+        Member owner = member(1L);
+        Group group = group(10L, owner);
+        GroupMember groupMember = GroupMember.create(owner, group);
+        when(memberRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+        when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+        when(groupMemberRepository.findByMember_IdAndGroup_Id(owner.getId(), group.getId()))
+                .thenReturn(Optional.of(groupMember));
+        when(groupMemberRepository.countByGroup_Id(group.getId())).thenReturn(1L);
+
+        groupCommandService.leaveGroup(owner.getId(), group.getId());
+
+        verify(groupMemberRepository).delete(groupMember);
+        assertThat(group.getMember()).isNull();
+    }
+
+    @Test
+    void leaveGroupThrowsWhenRequesterIsNotGroupMember() {
+        Member requester = member(2L);
+        Group group = group(10L, member(1L));
+        when(memberRepository.findById(requester.getId())).thenReturn(Optional.of(requester));
+        when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+        when(groupMemberRepository.findByMember_IdAndGroup_Id(requester.getId(), group.getId()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> groupCommandService.leaveGroup(requester.getId(), group.getId()))
+                .isInstanceOf(GroupDomainException.class)
+                .hasMessage(GroupErrorCode.GROUP_MEMBER_NOT_FOUND.getMessage());
+    }
+
+    private Member member(Long id) {
+        Member member = Member.create("member" + id + "@test.com", "member" + id, null, null);
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    private Group group(Long id, Member owner) {
+        Group group = Group.create("group", "title", "content", owner, null, true, 10);
+        ReflectionTestUtils.setField(group, "id", id);
+        return group;
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈


- resolves #20 

## 🚀 작업 내용

- 그룹 삭제 API 추가
- 그룹 탈퇴 API 추가
- 그룹 삭제 시 comment, group_member, group_category, activity_group 연관 데이터 정리
- 작성자는 그룹에 혼자 남았을 때만 탈퇴 가능하도록 비즈니스 규칙 적용
- 삭제/탈퇴 비즈니스 로직 단위 테스트 추가

## 💬 리뷰 중점사항

- 그룹 작성자만 삭제 가능
- 작성자가 아니면 그룹 삭제 실패
- 일반 그룹 멤버 탈퇴 가능
- 작성자는 다른 멤버가 남아 있으면 탈퇴 실패
- 작성자가 혼자 남았을 때만 탈퇴 가능
- 그룹 멤버가 아니면 탈퇴 실패

## 그룹 삭제 API
<img width="1424" height="645" alt="image" src="https://github.com/user-attachments/assets/637a9447-4ca0-432c-a2b5-e8eeedb7f9b8" />


```http
DELETE /api/v1/groups/{groupId}?memberId={memberId}
```

설명: 그룹 삭제 API. 그룹 작성자만 삭제할 수 있으며, 삭제 시 그룹 댓글, 그룹 멤버, 그룹 카테고리, 활동-그룹 매핑이 함께 삭제됩니다.

응답:
```http
204 또는 200 OK
Body 없음
```

## 그룹 탈퇴
<img width="1423" height="646" alt="image" src="https://github.com/user-attachments/assets/6587c086-ba70-4f5e-9b89-fc3613095926" />


```http
DELETE /api/v1/groups/{groupId}/members/me?memberId={memberId}
```

설명: 그룹 탈퇴 API. 그룹 멤버만 탈퇴할 수 있습니다. 작성자는 다른 팀원이 모두 탈퇴하고 혼자 남은 경우에만 탈퇴할 수 있으며, 이때 그룹 작성자 참조는 null 처리됩니다.

응답:
```http
204 또는 200 OK
Body 없음
```



## 쿼리문
```
-- 1. 멤버(Member) 데이터 5명 생성
INSERT INTO member (email, name, image_url, introduction, point, created_at, updated_at) VALUES
('alice@example.com', '개발하는앨리스', null, '안녕하세요, 꾸준히 성장하고 싶은 개발자입니다.', 0, NOW(), NOW()),
('bob@example.com', '런닝맨밥', null, '주말마다 뛰는 것을 좋아합니다.', 0, NOW(), NOW()),
('charlie@example.com', '찰리찰리', null, '다양한 사람들과 교류하고 싶어요.', 0, NOW(), NOW()),
('david@example.com', '여행자데이빗', null, '국내외 맛집과 여행지를 기록합니다.', 0, NOW(), NOW()),
('eve@example.com', '보드게임마스터', null, '주말엔 역시 보드게임이죠.', 0, NOW(), NOW());

-- 2. 카테고리(Category) 데이터 생성 (업로드해주신 이미지 기준 반영)
INSERT INTO category (name) VALUES
('STUDY'), ('PROJECT'), ('SOCIAL'), ('HOBBY'), ('SPORTS'), ('TRAVEL'), ('NETWORKING'), ('ETC');

-- 3. 그룹(Group) 데이터 8개 생성
INSERT INTO `groups` (name, title, content, member_id, image_url, is_public, capacity, created_at, updated_at) VALUES
('CS 전공지식 스터디', '운영체제/네트워크 딥다이브 하실 분', '매주 주말 강남역에서 모여서 발표 및 토론하는 스터디입니다.', 1, null, true, 6, NOW(), NOW()),
('사이드 프로젝트 팀원 모집', '웹 서비스 런칭 목적 프로젝트', '기획 1, 디자인 1, 프론트/백엔드 개발자 구합니다.', 1, null, true, 5, NOW(), NOW()),
('주말 한강 러닝크루', '초보 환영! 매주 토요일 아침 러닝', '페이스 상관없이 즐겁게 뛸 분들 모집해요. 뒤풀이도 있습니다.', 2, null, true, 15, NOW(), NOW()),
('도쿄 맛집 탐방팟', '10월 연휴 도쿄 여행 동행 구함', '미식 투어 위주로 일정 짜서 가볍게 다녀오실 분?', 4, null, true, 4, NOW(), NOW()),
('IT 직장인 네트워킹', '판교/강남권 개발자 네트워킹', '서로 인사이트도 나누고 커피챗 하실 분들 들어오세요.', 3, null, true, 20, NOW(), NOW()),
('전략 보드게임 동호회', '무거운 보드게임 위주로 돌아갑니다', '테라포밍마스, 아그리콜라 등 헤비 게임 좋아하시는 분 환영', 5, null, true, 8, NOW(), NOW()),
('모각코(모여서 각자 코딩)', '주말 오전 홍대 카페 모각코', '아무나 오셔서 각자 할 일 하시면 됩니다. 출석만 체크해요.', 1, null, true, 10, NOW(), NOW()),
('기타 소모임 테스트용', '테스트 목적의 비공개 그룹', '내용 없음', 3, null, false, 5, NOW(), NOW());

-- 4. 그룹 카테고리(GroupCategory) 매핑 데이터 생성
-- (위 카테고리 ID: 1=STUDY, 2=PROJECT, 3=SOCIAL, 4=HOBBY, 5=SPORTS, 6=TRAVEL, 7=NETWORKING, 8=ETC)
INSERT INTO group_category (group_id, category_id) VALUES
(1, 1),           -- 1번 그룹: STUDY
(2, 2), (2, 7),   -- 2번 그룹: PROJECT, NETWORKING
(3, 5), (3, 3),   -- 3번 그룹: SPORTS, SOCIAL
(4, 6),           -- 4번 그룹: TRAVEL
(5, 7), (5, 3),   -- 5번 그룹: NETWORKING, SOCIAL
(6, 4),           -- 6번 그룹: HOBBY
(7, 1),           -- 7번 그룹: STUDY
(8, 8);           -- 8번 그룹: ETC

-- 5. 그룹 멤버(GroupMember) 데이터 생성 (방장은 무조건 포함되도록 세팅)
INSERT INTO group_member (group_id, member_id) VALUES
(1, 1), (1, 3), (1, 5), -- 1번 그룹(방장1)에 1,3,5 참여
(2, 1), (2, 2),         -- 2번 그룹(방장1)에 1,2 참여
(3, 2), (3, 4), (3, 5), -- 3번 그룹(방장2)에 2,4,5 참여
(4, 4), (4, 2),         -- 4번 그룹(방장4)에 4,2 참여
(5, 3),                 -- 5번 그룹(방장3) 혼자
(6, 5), (6, 1),         -- 6번 그룹(방장5)에 5,1 참여
(7, 1), (7, 2), (7, 3), -- 7번 그룹(방장1)에 1,2,3 참여
(8, 3);                 -- 8번 그룹(방장3) 혼자

-- 6. 댓글(Comment) 데이터 생성 (일부 그룹에만 작성)
INSERT INTO comment (group_id, member_id, parent_id, content, created_at, updated_at) VALUES
(1, 3, null, '혹시 교재는 어떤 걸로 진행하나요?', NOW(), NOW()),
(1, 1, 1, '공룡책(Silberschatz)으로 진행할 예정입니다!', NOW(), NOW()), -- 대댓글(parent_id = 1)
(2, 2, null, '프론트엔드 포지션 아직 자리 있나요?', NOW(), NOW()),
(3, 5, null, '초보인데 5km 완주 가능할까요?', NOW(), NOW()),
(4, 2, null, '맛집 리스트 공유해주실 수 있나요?', NOW(), NOW()),
(6, 1, null, '초보자도 룰 설명 듣고 참여할 수 있는지 궁금합니다.', NOW(), NOW());
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 그룹 소유자는 그룹을 삭제할 수 있으며, 관련된 모든 활동 기록도 함께 제거됩니다
  * 그룹 멤버는 그룹을 탈퇴할 수 있습니다. 다른 멤버가 남아있으면 그룹 소유자는 탈퇴할 수 없습니다
  * 그룹 관리 엔드포인트의 API 문서가 개선되었습니다

* **테스트**
  * 그룹 삭제 및 멤버 탈퇴 작업에 대한 포괄적인 테스트가 추가되었습니다

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GCU-makeGroup/MGW-server/pull/21)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->