### PR TITLE
Feat/#19 활동 조회, 상세조회, 참여 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+instructions/
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/awp/mgw/activity/controller/ActivityController.java
+++ b/src/main/java/com/awp/mgw/activity/controller/ActivityController.java
@@ -1,22 +1,29 @@
 package com.awp.mgw.activity.controller;
 
 import com.awp.mgw.activity.controller.dto.request.CreateActivityRequest;
+import com.awp.mgw.activity.controller.dto.request.JoinActivityRequest;
 import com.awp.mgw.activity.controller.dto.request.UpdateActivityRequest;
+import com.awp.mgw.activity.controller.dto.response.ActivityDetailResponse;
 import com.awp.mgw.activity.controller.dto.response.ActivityIdResponse;
+import com.awp.mgw.activity.controller.dto.response.ActivityListResponse;
 import com.awp.mgw.activity.usecase.CreateActivityUseCase;
 import com.awp.mgw.activity.usecase.DeleteActivityUseCase;
+import com.awp.mgw.activity.usecase.GetActivityDetailUseCase;
+import com.awp.mgw.activity.usecase.GetActivityListUseCase;
+import com.awp.mgw.activity.usecase.JoinActivityUseCase;
 import com.awp.mgw.activity.usecase.UpdateActivityUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,6 +35,9 @@ public class ActivityController {
     private final CreateActivityUseCase createActivityUseCase;
     private final UpdateActivityUseCase updateActivityUseCase;
     private final DeleteActivityUseCase deleteActivityUseCase;
+    private final GetActivityListUseCase getActivityListUseCase;
+    private final GetActivityDetailUseCase getActivityDetailUseCase;
+    private final JoinActivityUseCase joinActivityUseCase;
 
     @PostMapping
     @Operation(summary = "활동 생성", description = "신규 활동을 생성합니다.")
@@ -55,5 +65,35 @@ public class ActivityController {
         @PathVariable Long activityId
     ) {
         return deleteActivityUseCase.deleteActivity(memberId, activityId);
+    }
+
+    @GetMapping
+    @Operation(summary = "활동 통합 조회", description = "scope, category, cursor 조건으로 활동 목록을 조회합니다.")
+    public ActivityListResponse getActivities(
+            @RequestParam(required = false) Long memberId,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String scope,
+            @RequestParam(required = false) Long cursor
+    ) {
+        return getActivityListUseCase.getActivityList(memberId, category, scope, cursor);
+    }
+
+    @GetMapping("/{activityId}/details")
+    @Operation(summary = "활동 상세 조회", description = "활동 상세 정보를 조회합니다.")
+    public ActivityDetailResponse getActivityDetail(
+        @RequestParam(required = false) Long memberId,
+        @PathVariable Long activityId
+    ) {
+        return getActivityDetailUseCase.getActivityDetail(memberId, activityId);
+    }
+
+    @PostMapping("/{activityId}/members")
+    @Operation(summary = "활동 참여", description = "개인 또는 그룹으로 활동에 참여합니다.")
+    public ActivityIdResponse joinActivity(
+        @RequestParam Long memberId,
+        @PathVariable Long activityId,
+        @Valid @RequestBody JoinActivityRequest request
+    ) {
+        return joinActivityUseCase.joinActivity(memberId, activityId, request);
     }
 }

--- a/src/main/java/com/awp/mgw/activity/controller/ActivityController.java
+++ b/src/main/java/com/awp/mgw/activity/controller/ActivityController.java
@@ -81,7 +81,7 @@ public class ActivityController {
     @GetMapping("/{activityId}/details")
     @Operation(summary = "활동 상세 조회", description = "활동 상세 정보를 조회합니다.")
     public ActivityDetailResponse getActivityDetail(
-        @RequestParam(required = false) Long memberId,
+        @RequestParam Long memberId,
         @PathVariable Long activityId
     ) {
         return getActivityDetailUseCase.getActivityDetail(memberId, activityId);

--- a/src/main/java/com/awp/mgw/activity/controller/dto/request/JoinActivityRequest.java
+++ b/src/main/java/com/awp/mgw/activity/controller/dto/request/JoinActivityRequest.java
@@ -1,0 +1,14 @@
+package com.awp.mgw.activity.controller.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record JoinActivityRequest(
+    @NotNull(message = "참여 유형은 필수입니다.")
+    ParticipationType participationType,
+    Long groupId
+) {
+    public enum ParticipationType {
+        INDIVIDUAL,
+        GROUP
+    }
+}

--- a/src/main/java/com/awp/mgw/activity/controller/dto/request/JoinActivityRequest.java
+++ b/src/main/java/com/awp/mgw/activity/controller/dto/request/JoinActivityRequest.java
@@ -1,12 +1,21 @@
 package com.awp.mgw.activity.controller.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.AssertTrue;
 
 public record JoinActivityRequest(
     @NotNull(message = "참여 유형은 필수입니다.")
     ParticipationType participationType,
     Long groupId
 ) {
+    @AssertTrue(message = "GROUP 참여 시 groupId는 필수입니다.")
+    public boolean isGroupIdValidForParticipationType() {
+        if (participationType == ParticipationType.GROUP) {
+            return groupId != null;
+        }
+        return true;
+    }
+
     public enum ParticipationType {
         INDIVIDUAL,
         GROUP

--- a/src/main/java/com/awp/mgw/activity/controller/dto/response/ActivityDetailResponse.java
+++ b/src/main/java/com/awp/mgw/activity/controller/dto/response/ActivityDetailResponse.java
@@ -1,0 +1,27 @@
+package com.awp.mgw.activity.controller.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ActivityDetailResponse(
+    Long id,
+    String title,
+    String category,
+    Integer capacity,
+    Long currentParticipants,
+    Boolean isLiked,
+    Long likeCount,
+    Instant schedule,
+    String thumbnail,
+    Boolean isHotpick,
+    String description,
+    List<ActivityMemberResponse> members,
+    String openChatUrl
+) {
+    public record ActivityMemberResponse(
+        Long userId,
+        String name,
+        String profileImg
+    ) {
+    }
+}

--- a/src/main/java/com/awp/mgw/activity/controller/dto/response/ActivityListResponse.java
+++ b/src/main/java/com/awp/mgw/activity/controller/dto/response/ActivityListResponse.java
@@ -1,0 +1,10 @@
+package com.awp.mgw.activity.controller.dto.response;
+
+import java.util.List;
+
+public record ActivityListResponse(
+    ActivitySummaryResponse hotpick,
+    List<ActivitySummaryResponse> activities,
+    String nextCursor
+) {
+}

--- a/src/main/java/com/awp/mgw/activity/controller/dto/response/ActivitySummaryResponse.java
+++ b/src/main/java/com/awp/mgw/activity/controller/dto/response/ActivitySummaryResponse.java
@@ -1,0 +1,17 @@
+package com.awp.mgw.activity.controller.dto.response;
+
+import java.time.Instant;
+
+public record ActivitySummaryResponse(
+    Long id,
+    String title,
+    String category,
+    Integer capacity,
+    Long currentParticipants,
+    Boolean isLiked,
+    Long likeCount,
+    Instant schedule,
+    String thumbnail,
+    Boolean isHotpick
+) {
+}

--- a/src/main/java/com/awp/mgw/activity/domain/ActivityGroup.java
+++ b/src/main/java/com/awp/mgw/activity/domain/ActivityGroup.java
@@ -14,12 +14,21 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "activity_group")
+@Table(
+    name = "activity_group",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_activity_group_activity_group_status",
+            columnNames = {"activity_id", "group_id", "status"}
+        )
+    }
+)
 public class ActivityGroup extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/awp/mgw/activity/domain/exception/ActivityErrorCode.java
+++ b/src/main/java/com/awp/mgw/activity/domain/exception/ActivityErrorCode.java
@@ -28,6 +28,7 @@ public enum ActivityErrorCode implements BaseCode {
     ACTIVITY_CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "ACTIVITY-015", "활동 정원이 가득 찼습니다."),
     DUPLICATE_ACTIVITY_MEMBER_JOIN(HttpStatus.CONFLICT, "ACTIVITY-016", "이미 활동에 참여 중인 사용자입니다."),
     DUPLICATE_ACTIVITY_GROUP_JOIN(HttpStatus.CONFLICT, "ACTIVITY-017", "이미 활동에 참여 중인 그룹입니다."),
+    MEMBER_ID_REQUIRED_FOR_SCOPE(HttpStatus.BAD_REQUEST, "ACTIVITY-018", "joined/created 조회에는 memberId가 필요합니다."),
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/awp/mgw/activity/domain/exception/ActivityErrorCode.java
+++ b/src/main/java/com/awp/mgw/activity/domain/exception/ActivityErrorCode.java
@@ -24,6 +24,10 @@ public enum ActivityErrorCode implements BaseCode {
     ACTIVITY_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "ACTIVITY-011", "활동에 연결된 카테고리를 찾을 수 없습니다."),
     ACTIVITY_LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "ACTIVITY-012", "활동 좋아요 정보를 찾을 수 없습니다."),
     INVALID_ACTIVITY_GROUP_STATUS(HttpStatus.BAD_REQUEST, "ACTIVITY-013", "활동 그룹 상태값이 유효하지 않습니다."),
+    FORBIDDEN_ACTIVITY_ACCESS(HttpStatus.FORBIDDEN, "ACTIVITY-014", "활동에 대한 권한이 없습니다."),
+    ACTIVITY_CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "ACTIVITY-015", "활동 정원이 가득 찼습니다."),
+    DUPLICATE_ACTIVITY_MEMBER_JOIN(HttpStatus.CONFLICT, "ACTIVITY-016", "이미 활동에 참여 중인 사용자입니다."),
+    DUPLICATE_ACTIVITY_GROUP_JOIN(HttpStatus.CONFLICT, "ACTIVITY-017", "이미 활동에 참여 중인 그룹입니다."),
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/awp/mgw/activity/port/ActivityGroupRepository.java
+++ b/src/main/java/com/awp/mgw/activity/port/ActivityGroupRepository.java
@@ -1,0 +1,11 @@
+package com.awp.mgw.activity.port;
+
+import com.awp.mgw.activity.domain.Activity;
+import com.awp.mgw.activity.domain.ActivityGroup;
+import com.awp.mgw.activity.domain.enums.ActivityGroupStatus;
+import com.awp.mgw.group.domain.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityGroupRepository extends JpaRepository<ActivityGroup, Long> {
+    boolean existsByActivityAndGroupAndStatusIn(Activity activity, Group group, Iterable<ActivityGroupStatus> statuses);
+}

--- a/src/main/java/com/awp/mgw/activity/port/ActivityQueryRepository.java
+++ b/src/main/java/com/awp/mgw/activity/port/ActivityQueryRepository.java
@@ -11,7 +11,6 @@ import com.awp.mgw.group.domain.QGroup;
 import com.awp.mgw.group.domain.QGroupMember;
 import com.awp.mgw.member.domain.QMember;
 import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -22,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -60,7 +60,7 @@ public class ActivityQueryRepository {
                 categoryFilter(categoryName),
                 scopeFilter(scope, memberId)
             )
-            .orderBy(orderByScope(scope))
+            .orderBy(activity.id.desc())
             .limit(size)
             .fetch();
     }
@@ -158,6 +158,22 @@ public class ActivityQueryRepository {
         return exists != null;
     }
 
+    public boolean existsMemberInActivityByStatuses(Long activityId, Long memberId, Collection<ActivityGroupStatus> statuses) {
+        Integer exists = queryFactory
+            .selectOne()
+            .from(activityGroup)
+            .join(activityGroup.group, group)
+            .join(group.groupMembers, groupMember)
+            .where(
+                activityGroup.activity.id.eq(activityId),
+                activityGroup.status.in(statuses),
+                groupMember.member.id.eq(memberId)
+            )
+            .fetchFirst();
+
+        return exists != null;
+    }
+
     public boolean existsMemberInGroup(Long groupId, Long memberId) {
         Integer exists = queryFactory
             .selectOne()
@@ -197,12 +213,36 @@ public class ActivityQueryRepository {
             .fetchFirst();
     }
 
-    private OrderSpecifier<?>[] orderByScope(String scope) {
-        if ("hotpick".equalsIgnoreCase(scope)) {
-            return new OrderSpecifier[]{scoreExpression(activity.id).desc(), activity.id.desc()};
-        }
+    public long countGroupMembers(Long groupId) {
+        Long count = queryFactory
+            .select(groupMember.member.id.countDistinct())
+            .from(groupMember)
+            .where(groupMember.group.id.eq(groupId))
+            .fetchOne();
 
-        return new OrderSpecifier[]{activity.id.desc()};
+        return count == null ? 0L : count;
+    }
+
+    public long countAlreadyJoinedMembersFromGroup(Long activityId, Long groupId) {
+        QGroupMember joinTargetMembers = new QGroupMember("joinTargetMembers");
+
+        Long count = queryFactory
+            .select(groupMember.member.id.countDistinct())
+            .from(activityGroup)
+            .join(activityGroup.group, group)
+            .join(group.groupMembers, groupMember)
+            .where(
+                activityGroup.activity.id.eq(activityId),
+                activityGroup.status.eq(ActivityGroupStatus.JOIN),
+                groupMember.member.id.in(
+                    JPAExpressions.select(joinTargetMembers.member.id)
+                        .from(joinTargetMembers)
+                        .where(joinTargetMembers.group.id.eq(groupId))
+                )
+            )
+            .fetchOne();
+
+        return count == null ? 0L : count;
     }
 
     private BooleanExpression cursorLt(Long cursor) {
@@ -253,10 +293,20 @@ public class ActivityQueryRepository {
     }
 
     private Expression<String> categoryNameExpression() {
-        return JPAExpressions.select(category.name.min())
-            .from(activityCategory)
-            .join(activityCategory.category, category)
-            .where(activityCategory.activity.id.eq(activity.id));
+        QActivityCategory categoryPick = new QActivityCategory("categoryPick");
+        QActivityCategory categoryMin = new QActivityCategory("categoryMin");
+        QCategory categoryPickCategory = new QCategory("categoryPickCategory");
+
+        return JPAExpressions.select(categoryPickCategory.name)
+            .from(categoryPick)
+            .join(categoryPick.category, categoryPickCategory)
+            .where(
+                categoryPick.id.eq(
+                    JPAExpressions.select(categoryMin.id.min())
+                        .from(categoryMin)
+                        .where(categoryMin.activity.id.eq(activity.id))
+                )
+            );
     }
 
     private NumberExpression<Long> currentParticipantCountExpression(Expression<Long> activityIdExpression) {

--- a/src/main/java/com/awp/mgw/activity/port/ActivityQueryRepository.java
+++ b/src/main/java/com/awp/mgw/activity/port/ActivityQueryRepository.java
@@ -1,0 +1,330 @@
+package com.awp.mgw.activity.port;
+
+import com.awp.mgw.activity.domain.QActivity;
+import com.awp.mgw.activity.domain.QActivityCategory;
+import com.awp.mgw.activity.domain.QActivityGroup;
+import com.awp.mgw.activity.domain.QActivityLike;
+import com.awp.mgw.activity.domain.enums.ActivityGroupStatus;
+import com.awp.mgw.category.domain.QCategory;
+import com.awp.mgw.group.domain.Group;
+import com.awp.mgw.group.domain.QGroup;
+import com.awp.mgw.group.domain.QGroupMember;
+import com.awp.mgw.member.domain.QMember;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ActivityQueryRepository {
+
+    private static final QActivity activity = QActivity.activity;
+    private static final QActivityCategory activityCategory = QActivityCategory.activityCategory;
+    private static final QCategory category = QCategory.category;
+    private static final QActivityLike activityLike = QActivityLike.activityLike;
+    private static final QActivityGroup activityGroup = QActivityGroup.activityGroup;
+    private static final QGroup group = QGroup.group;
+    private static final QGroupMember groupMember = QGroupMember.groupMember;
+    private static final QMember member = QMember.member;
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<ActivitySummaryRow> findActivitySummaries(Long memberId, String categoryName, String scope, Long cursor, int size) {
+        return queryFactory
+            .select(Projections.constructor(
+                ActivitySummaryRow.class,
+                activity.id,
+                activity.title,
+                categoryNameExpression(),
+                activity.maxMember,
+                currentParticipantCountExpression(activity.id),
+                isLikedExpression(memberId, activity.id),
+                likeCountExpression(activity.id),
+                activity.schedule,
+                activity.thumbnailUrl,
+                scoreExpression(activity.id)
+            ))
+            .from(activity)
+            .where(
+                cursorLt(cursor),
+                categoryFilter(categoryName),
+                scopeFilter(scope, memberId)
+            )
+            .orderBy(orderByScope(scope))
+            .limit(size)
+            .fetch();
+    }
+
+    public ActivitySummaryRow findTopHotpick(Long memberId, String categoryName) {
+        return queryFactory
+            .select(Projections.constructor(
+                ActivitySummaryRow.class,
+                activity.id,
+                activity.title,
+                categoryNameExpression(),
+                activity.maxMember,
+                currentParticipantCountExpression(activity.id),
+                isLikedExpression(memberId, activity.id),
+                likeCountExpression(activity.id),
+                activity.schedule,
+                activity.thumbnailUrl,
+                scoreExpression(activity.id)
+            ))
+            .from(activity)
+            .where(categoryFilter(categoryName))
+            .orderBy(scoreExpression(activity.id).desc(), activity.id.desc())
+            .limit(1)
+            .fetchOne();
+    }
+
+    public ActivitySummaryRow findActivitySummaryById(Long activityId, Long memberId) {
+        return queryFactory
+            .select(Projections.constructor(
+                ActivitySummaryRow.class,
+                activity.id,
+                activity.title,
+                categoryNameExpression(),
+                activity.maxMember,
+                currentParticipantCountExpression(activity.id),
+                isLikedExpression(memberId, activity.id),
+                likeCountExpression(activity.id),
+                activity.schedule,
+                activity.thumbnailUrl,
+                scoreExpression(activity.id)
+            ))
+            .from(activity)
+            .where(activity.id.eq(activityId))
+            .fetchOne();
+    }
+
+    public List<ActivityParticipantRow> findParticipants(Long activityId) {
+        return queryFactory
+            .select(Projections.constructor(
+                ActivityParticipantRow.class,
+                member.id,
+                member.name,
+                member.imageUrl
+            ))
+            .from(activityGroup)
+            .join(activityGroup.group, group)
+            .join(group.groupMembers, groupMember)
+            .join(groupMember.member, member)
+            .where(
+                activityGroup.activity.id.eq(activityId),
+                activityGroup.status.eq(ActivityGroupStatus.JOIN)
+            )
+            .distinct()
+            .fetch();
+    }
+
+    public long countJoinedParticipants(Long activityId) {
+        Long count = queryFactory
+            .select(groupMember.member.id.countDistinct())
+            .from(activityGroup)
+            .join(activityGroup.group, group)
+            .join(group.groupMembers, groupMember)
+            .where(
+                activityGroup.activity.id.eq(activityId),
+                activityGroup.status.eq(ActivityGroupStatus.JOIN)
+            )
+            .fetchOne();
+
+        return count == null ? 0L : count;
+    }
+
+    public boolean existsJoinedMember(Long activityId, Long memberId) {
+        Integer exists = queryFactory
+            .selectOne()
+            .from(activityGroup)
+            .join(activityGroup.group, group)
+            .join(group.groupMembers, groupMember)
+            .where(
+                activityGroup.activity.id.eq(activityId),
+                activityGroup.status.eq(ActivityGroupStatus.JOIN),
+                groupMember.member.id.eq(memberId)
+            )
+            .fetchFirst();
+
+        return exists != null;
+    }
+
+    public boolean existsMemberInGroup(Long groupId, Long memberId) {
+        Integer exists = queryFactory
+            .selectOne()
+            .from(groupMember)
+            .where(
+                groupMember.group.id.eq(groupId),
+                groupMember.member.id.eq(memberId)
+            )
+            .fetchFirst();
+
+        return exists != null;
+    }
+
+    public Group findSingleMemberGroup(Long memberId) {
+        QGroupMember memberCountAlias = new QGroupMember("memberCountAlias");
+        QGroupMember memberExistsAlias = new QGroupMember("memberExistsAlias");
+
+        return queryFactory
+            .selectFrom(group)
+            .where(
+                group.member.id.eq(memberId),
+                group.capacity.eq(1),
+                group.isPublic.isFalse(),
+                JPAExpressions.select(memberCountAlias.id.count())
+                    .from(memberCountAlias)
+                    .where(memberCountAlias.group.id.eq(group.id))
+                    .eq(1L),
+                JPAExpressions.selectOne()
+                    .from(memberExistsAlias)
+                    .where(
+                        memberExistsAlias.group.id.eq(group.id),
+                        memberExistsAlias.member.id.eq(memberId)
+                    )
+                    .exists()
+            )
+            .orderBy(group.id.desc())
+            .fetchFirst();
+    }
+
+    private OrderSpecifier<?>[] orderByScope(String scope) {
+        if ("hotpick".equalsIgnoreCase(scope)) {
+            return new OrderSpecifier[]{scoreExpression(activity.id).desc(), activity.id.desc()};
+        }
+
+        return new OrderSpecifier[]{activity.id.desc()};
+    }
+
+    private BooleanExpression cursorLt(Long cursor) {
+        if (cursor == null) {
+            return null;
+        }
+        return activity.id.lt(cursor);
+    }
+
+    private BooleanExpression categoryFilter(String categoryName) {
+        if (categoryName == null || categoryName.isBlank()) {
+            return null;
+        }
+
+        return JPAExpressions.selectOne()
+            .from(activityCategory)
+            .join(activityCategory.category, category)
+            .where(
+                activityCategory.activity.id.eq(activity.id),
+                category.name.eq(categoryName)
+            )
+            .exists();
+    }
+
+    private BooleanExpression scopeFilter(String scope, Long memberId) {
+        if (scope == null || scope.isBlank() || "hotpick".equalsIgnoreCase(scope)) {
+            return null;
+        }
+
+        if ("created".equalsIgnoreCase(scope)) {
+            return activity.creator.id.eq(memberId);
+        }
+
+        if ("joined".equalsIgnoreCase(scope)) {
+            return JPAExpressions.selectOne()
+                .from(activityGroup)
+                .join(activityGroup.group, group)
+                .join(group.groupMembers, groupMember)
+                .where(
+                    activityGroup.activity.id.eq(activity.id),
+                    activityGroup.status.eq(ActivityGroupStatus.JOIN),
+                    groupMember.member.id.eq(memberId)
+                )
+                .exists();
+        }
+
+        return null;
+    }
+
+    private Expression<String> categoryNameExpression() {
+        return JPAExpressions.select(category.name.min())
+            .from(activityCategory)
+            .join(activityCategory.category, category)
+            .where(activityCategory.activity.id.eq(activity.id));
+    }
+
+    private NumberExpression<Long> currentParticipantCountExpression(Expression<Long> activityIdExpression) {
+        return Expressions.numberTemplate(
+            Long.class,
+            "coalesce(({0}), 0)",
+            JPAExpressions.select(groupMember.member.id.countDistinct())
+                .from(activityGroup)
+                .join(activityGroup.group, group)
+                .join(group.groupMembers, groupMember)
+                .where(
+                    activityGroup.activity.id.eq(activityIdExpression),
+                    activityGroup.status.eq(ActivityGroupStatus.JOIN)
+                )
+        );
+    }
+
+    private NumberExpression<Long> likeCountExpression(Expression<Long> activityIdExpression) {
+        return Expressions.numberTemplate(
+            Long.class,
+            "coalesce(({0}), 0)",
+            JPAExpressions.select(activityLike.id.count())
+                .from(activityLike)
+                .where(activityLike.activity.id.eq(activityIdExpression))
+        );
+    }
+
+    private Expression<Boolean> isLikedExpression(Long memberId, Expression<Long> activityIdExpression) {
+        if (memberId == null) {
+            return Expressions.asBoolean(false);
+        }
+
+        return JPAExpressions.selectOne()
+            .from(activityLike)
+            .where(
+                activityLike.activity.id.eq(activityIdExpression),
+                activityLike.member.id.eq(memberId)
+            )
+            .exists();
+    }
+
+    private NumberExpression<Long> scoreExpression(Expression<Long> activityIdExpression) {
+        return Expressions.numberTemplate(
+            Long.class,
+            "(({0}) * 2 + ({1}))",
+            likeCountExpression(activityIdExpression),
+            currentParticipantCountExpression(activityIdExpression)
+        );
+    }
+
+    public record ActivitySummaryRow(
+        Long id,
+        String title,
+        String category,
+        Integer capacity,
+        Long currentParticipants,
+        Boolean isLiked,
+        Long likeCount,
+        Instant schedule,
+        String thumbnail,
+        Long score
+    ) {
+    }
+
+    public record ActivityParticipantRow(
+        Long userId,
+        String name,
+        String profileImg
+    ) {
+    }
+}

--- a/src/main/java/com/awp/mgw/activity/port/ActivityRepository.java
+++ b/src/main/java/com/awp/mgw/activity/port/ActivityRepository.java
@@ -1,7 +1,15 @@
 package com.awp.mgw.activity.port;
 
 import com.awp.mgw.activity.domain.Activity;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface ActivityRepository extends JpaRepository<Activity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select a from Activity a where a.id = :id")
+    Optional<Activity> findByIdForUpdate(Long id);
 }

--- a/src/main/java/com/awp/mgw/activity/service/ActivityCommandService.java
+++ b/src/main/java/com/awp/mgw/activity/service/ActivityCommandService.java
@@ -31,6 +31,7 @@ import com.awp.mgw.member.domain.exception.MemberDomainException;
 import com.awp.mgw.member.domain.exception.MemberErrorCode;
 import com.awp.mgw.member.port.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -106,17 +107,18 @@ public class ActivityCommandService implements CreateActivityUseCase, UpdateActi
     @Override
     public ActivityIdResponse joinActivity(Long memberId, Long activityId, JoinActivityRequest request) {
         Member member = getMemberOrThrow(memberId);
-        Activity activity = getActivityOrThrow(activityId);
-
-        validateCapacity(activity);
-        if (activityQueryRepository.existsJoinedMember(activityId, memberId)) {
-            throw new ActivityDomainException(ActivityErrorCode.DUPLICATE_ACTIVITY_MEMBER_JOIN);
-        }
-
         Group targetGroup = resolveJoinGroup(member, request);
-        validateGroupJoinDuplication(activity, targetGroup);
+        Activity activity = getActivityForUpdateOrThrow(activityId);
 
-        activityGroupRepository.save(ActivityGroup.create(activity, targetGroup, ActivityGroupStatus.JOIN));
+        validateGroupJoinDuplication(activity, targetGroup);
+        validateMemberJoinDuplication(activityId, memberId, targetGroup.getId());
+        validateCapacity(activity, targetGroup.getId());
+
+        try {
+            activityGroupRepository.save(ActivityGroup.create(activity, targetGroup, ActivityGroupStatus.JOIN));
+        } catch (DataIntegrityViolationException e) {
+            throw new ActivityDomainException(ActivityErrorCode.DUPLICATE_ACTIVITY_GROUP_JOIN);
+        }
         return ActivityIdResponse.from(activity.getId());
     }
 
@@ -138,6 +140,11 @@ public class ActivityCommandService implements CreateActivityUseCase, UpdateActi
         Activity activity = activityRepository.findById(activityId)
             .orElseThrow(() -> new ActivityDomainException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
         return activity;
+    }
+
+    private Activity getActivityForUpdateOrThrow(Long activityId) {
+        return activityRepository.findByIdForUpdate(activityId)
+            .orElseThrow(() -> new ActivityDomainException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
     }
 
     private void saveActivityCategories(Activity activity, List<Long> categoryIds) {
@@ -180,9 +187,13 @@ public class ActivityCommandService implements CreateActivityUseCase, UpdateActi
         return categories;
     }
 
-    private void validateCapacity(Activity activity) {
+    private void validateCapacity(Activity activity, Long groupId) {
         long currentParticipants = activityQueryRepository.countJoinedParticipants(activity.getId());
-        if (currentParticipants >= activity.getMaxMember()) {
+        long groupMembers = activityQueryRepository.countGroupMembers(groupId);
+        long overlapMembers = activityQueryRepository.countAlreadyJoinedMembersFromGroup(activity.getId(), groupId);
+        long expectedParticipants = currentParticipants + Math.max(0L, groupMembers - overlapMembers);
+
+        if (expectedParticipants > activity.getMaxMember()) {
             throw new ActivityDomainException(ActivityErrorCode.ACTIVITY_CAPACITY_EXCEEDED);
         }
     }
@@ -224,6 +235,17 @@ public class ActivityCommandService implements CreateActivityUseCase, UpdateActi
     private void validateGroupJoinDuplication(Activity activity, Group group) {
         if (activityGroupRepository.existsByActivityAndGroupAndStatusIn(activity, group, ACTIVE_JOIN_STATUSES)) {
             throw new ActivityDomainException(ActivityErrorCode.DUPLICATE_ACTIVITY_GROUP_JOIN);
+        }
+    }
+
+    private void validateMemberJoinDuplication(Long activityId, Long memberId, Long groupId) {
+        if (activityQueryRepository.existsMemberInActivityByStatuses(activityId, memberId, ACTIVE_JOIN_STATUSES)) {
+            throw new ActivityDomainException(ActivityErrorCode.DUPLICATE_ACTIVITY_MEMBER_JOIN);
+        }
+
+        long overlapMembers = activityQueryRepository.countAlreadyJoinedMembersFromGroup(activityId, groupId);
+        if (overlapMembers > 0) {
+            throw new ActivityDomainException(ActivityErrorCode.DUPLICATE_ACTIVITY_MEMBER_JOIN);
         }
     }
 }

--- a/src/main/java/com/awp/mgw/activity/service/ActivityCommandService.java
+++ b/src/main/java/com/awp/mgw/activity/service/ActivityCommandService.java
@@ -1,21 +1,31 @@
 package com.awp.mgw.activity.service;
 
 import com.awp.mgw.activity.controller.dto.request.CreateActivityRequest;
+import com.awp.mgw.activity.controller.dto.request.JoinActivityRequest;
 import com.awp.mgw.activity.controller.dto.request.UpdateActivityRequest;
 import com.awp.mgw.activity.controller.dto.response.ActivityIdResponse;
 import com.awp.mgw.activity.domain.Activity;
 import com.awp.mgw.activity.domain.ActivityCategory;
+import com.awp.mgw.activity.domain.ActivityGroup;
+import com.awp.mgw.activity.domain.enums.ActivityGroupStatus;
 import com.awp.mgw.activity.domain.exception.ActivityDomainException;
 import com.awp.mgw.activity.domain.exception.ActivityErrorCode;
 import com.awp.mgw.activity.port.ActivityCategoryRepository;
+import com.awp.mgw.activity.port.ActivityGroupRepository;
+import com.awp.mgw.activity.port.ActivityQueryRepository;
 import com.awp.mgw.activity.port.ActivityRepository;
 import com.awp.mgw.activity.usecase.CreateActivityUseCase;
 import com.awp.mgw.activity.usecase.DeleteActivityUseCase;
+import com.awp.mgw.activity.usecase.JoinActivityUseCase;
 import com.awp.mgw.activity.usecase.UpdateActivityUseCase;
 import com.awp.mgw.category.domain.Category;
 import com.awp.mgw.category.domain.exception.CategoryDomainException;
 import com.awp.mgw.category.domain.exception.CategoryErrorCode;
 import com.awp.mgw.category.port.CategoryRepository;
+import com.awp.mgw.group.domain.Group;
+import com.awp.mgw.group.domain.GroupMember;
+import com.awp.mgw.group.port.GroupMemberRepository;
+import com.awp.mgw.group.port.GroupRepository;
 import com.awp.mgw.member.domain.Member;
 import com.awp.mgw.member.domain.exception.MemberDomainException;
 import com.awp.mgw.member.domain.exception.MemberErrorCode;
@@ -24,17 +34,28 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class ActivityCommandService implements CreateActivityUseCase, UpdateActivityUseCase, DeleteActivityUseCase {
+public class ActivityCommandService implements CreateActivityUseCase, UpdateActivityUseCase, DeleteActivityUseCase, JoinActivityUseCase {
+
+    private static final List<ActivityGroupStatus> ACTIVE_JOIN_STATUSES =
+        Arrays.asList(ActivityGroupStatus.PENDING, ActivityGroupStatus.JOIN);
+    private static final String PERSONAL_GROUP_NAME_PREFIX = "personal-member-";
+    private static final String PERSONAL_GROUP_TITLE_SUFFIX = "님의 1인 활동 그룹";
+    private static final String PERSONAL_GROUP_CONTENT = "자동 생성된 개인 참여 그룹";
 
     private final ActivityRepository activityRepository;
     private final ActivityCategoryRepository activityCategoryRepository;
+    private final ActivityGroupRepository activityGroupRepository;
+    private final ActivityQueryRepository activityQueryRepository;
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
     @Override
     public ActivityIdResponse createActivity(Long memberId, CreateActivityRequest request) {
@@ -82,19 +103,40 @@ public class ActivityCommandService implements CreateActivityUseCase, UpdateActi
         return ActivityIdResponse.from(activity.getId());
     }
 
+    @Override
+    public ActivityIdResponse joinActivity(Long memberId, Long activityId, JoinActivityRequest request) {
+        Member member = getMemberOrThrow(memberId);
+        Activity activity = getActivityOrThrow(activityId);
+
+        validateCapacity(activity);
+        if (activityQueryRepository.existsJoinedMember(activityId, memberId)) {
+            throw new ActivityDomainException(ActivityErrorCode.DUPLICATE_ACTIVITY_MEMBER_JOIN);
+        }
+
+        Group targetGroup = resolveJoinGroup(member, request);
+        validateGroupJoinDuplication(activity, targetGroup);
+
+        activityGroupRepository.save(ActivityGroup.create(activity, targetGroup, ActivityGroupStatus.JOIN));
+        return ActivityIdResponse.from(activity.getId());
+    }
+
     private Member getMemberOrThrow(Long memberId) {
         return memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberDomainException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
     private Activity getOwnedActivityOrThrow(Long activityId, Long memberId) {
-        Activity activity = activityRepository.findById(activityId)
-            .orElseThrow(() -> new ActivityDomainException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
-
+        Activity activity = getActivityOrThrow(activityId);
         if (activity.getCreator() == null || !activity.getCreator().getId().equals(memberId)) {
             throw new ActivityDomainException(ActivityErrorCode.FORBIDDEN_ACTIVITY_ACCESS);
         }
 
+        return activity;
+    }
+
+    private Activity getActivityOrThrow(Long activityId) {
+        Activity activity = activityRepository.findById(activityId)
+            .orElseThrow(() -> new ActivityDomainException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
         return activity;
     }
 
@@ -136,5 +178,52 @@ public class ActivityCommandService implements CreateActivityUseCase, UpdateActi
         }
 
         return categories;
+    }
+
+    private void validateCapacity(Activity activity) {
+        long currentParticipants = activityQueryRepository.countJoinedParticipants(activity.getId());
+        if (currentParticipants >= activity.getMaxMember()) {
+            throw new ActivityDomainException(ActivityErrorCode.ACTIVITY_CAPACITY_EXCEEDED);
+        }
+    }
+
+    private Group resolveJoinGroup(Member member, JoinActivityRequest request) {
+        if (request.participationType() == JoinActivityRequest.ParticipationType.GROUP) {
+            Long groupId = request.groupId();
+            if (groupId == null) {
+                throw new ActivityDomainException(ActivityErrorCode.ACTIVITY_GROUP_NOT_FOUND);
+            }
+
+            Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new ActivityDomainException(ActivityErrorCode.ACTIVITY_GROUP_NOT_FOUND));
+
+            if (!activityQueryRepository.existsMemberInGroup(groupId, member.getId())) {
+                throw new ActivityDomainException(ActivityErrorCode.FORBIDDEN_ACTIVITY_ACCESS);
+            }
+            return group;
+        }
+
+        Group singleMemberGroup = activityQueryRepository.findSingleMemberGroup(member.getId());
+        if (singleMemberGroup != null) {
+            return singleMemberGroup;
+        }
+
+        Group createdGroup = groupRepository.save(Group.create(
+            PERSONAL_GROUP_NAME_PREFIX + member.getId(),
+            member.getName() + PERSONAL_GROUP_TITLE_SUFFIX,
+            PERSONAL_GROUP_CONTENT,
+            member,
+            null,
+            false,
+            1
+        ));
+        groupMemberRepository.save(GroupMember.create(member, createdGroup));
+        return createdGroup;
+    }
+
+    private void validateGroupJoinDuplication(Activity activity, Group group) {
+        if (activityGroupRepository.existsByActivityAndGroupAndStatusIn(activity, group, ACTIVE_JOIN_STATUSES)) {
+            throw new ActivityDomainException(ActivityErrorCode.DUPLICATE_ACTIVITY_GROUP_JOIN);
+        }
     }
 }

--- a/src/main/java/com/awp/mgw/activity/service/ActivityQueryService.java
+++ b/src/main/java/com/awp/mgw/activity/service/ActivityQueryService.java
@@ -1,0 +1,110 @@
+package com.awp.mgw.activity.service;
+
+import com.awp.mgw.activity.controller.dto.response.ActivityDetailResponse;
+import com.awp.mgw.activity.controller.dto.response.ActivityListResponse;
+import com.awp.mgw.activity.controller.dto.response.ActivitySummaryResponse;
+import com.awp.mgw.activity.domain.Activity;
+import com.awp.mgw.activity.domain.exception.ActivityDomainException;
+import com.awp.mgw.activity.domain.exception.ActivityErrorCode;
+import com.awp.mgw.activity.port.ActivityQueryRepository;
+import com.awp.mgw.activity.port.ActivityRepository;
+import com.awp.mgw.activity.usecase.GetActivityDetailUseCase;
+import com.awp.mgw.activity.usecase.GetActivityListUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ActivityQueryService implements GetActivityListUseCase, GetActivityDetailUseCase {
+
+    private static final int PAGE_SIZE = 20;
+
+    private final ActivityRepository activityRepository;
+    private final ActivityQueryRepository activityQueryRepository;
+
+    @Override
+    public ActivityListResponse getActivityList(Long memberId, String category, String scope, Long cursor) {
+        List<ActivityQueryRepository.ActivitySummaryRow> rows =
+            activityQueryRepository.findActivitySummaries(memberId, category, scope, cursor, PAGE_SIZE + 1);
+
+        boolean hasNext = rows.size() > PAGE_SIZE;
+        List<ActivityQueryRepository.ActivitySummaryRow> pagedRows = hasNext ? rows.subList(0, PAGE_SIZE) : rows;
+
+        ActivitySummaryResponse hotpick = null;
+        if (scope == null || scope.isBlank()) {
+            ActivityQueryRepository.ActivitySummaryRow hotpickRow = activityQueryRepository.findTopHotpick(memberId, category);
+            hotpick = mapSummary(hotpickRow, hotpickRow != null ? hotpickRow.id() : null);
+        }
+
+        Long hotpickId = hotpick == null ? null : hotpick.id();
+        List<ActivitySummaryResponse> activities = pagedRows.stream()
+            .map(row -> mapSummary(row, hotpickId))
+            .toList();
+
+        String nextCursor = hasNext ? String.valueOf(pagedRows.get(pagedRows.size() - 1).id()) : null;
+        return new ActivityListResponse(hotpick, activities, nextCursor);
+    }
+
+    @Override
+    public ActivityDetailResponse getActivityDetail(Long memberId, Long activityId) {
+        Activity activity = activityRepository.findById(activityId)
+            .orElseThrow(() -> new ActivityDomainException(ActivityErrorCode.ACTIVITY_NOT_FOUND));
+
+        ActivityQueryRepository.ActivitySummaryRow row = activityQueryRepository.findActivitySummaryById(activityId, memberId);
+        if (row == null) {
+            throw new ActivityDomainException(ActivityErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        ActivityQueryRepository.ActivitySummaryRow hotpickRow = activityQueryRepository.findTopHotpick(memberId, null);
+        Long hotpickId = hotpickRow == null ? null : hotpickRow.id();
+        boolean isHotpick = hotpickId != null && hotpickId.equals(activityId);
+
+        List<ActivityDetailResponse.ActivityMemberResponse> members = activityQueryRepository.findParticipants(activityId).stream()
+            .map(participant -> new ActivityDetailResponse.ActivityMemberResponse(
+                participant.userId(),
+                participant.name(),
+                participant.profileImg()
+            ))
+            .toList();
+
+        return new ActivityDetailResponse(
+            row.id(),
+            row.title(),
+            row.category(),
+            row.capacity(),
+            row.currentParticipants(),
+            row.isLiked(),
+            row.likeCount(),
+            row.schedule(),
+            row.thumbnail(),
+            isHotpick,
+            activity.getDescription(),
+            members,
+            activity.getOpenchatUrl()
+        );
+    }
+
+    private ActivitySummaryResponse mapSummary(ActivityQueryRepository.ActivitySummaryRow row, Long hotpickId) {
+        if (row == null) {
+            return null;
+        }
+
+        boolean isHotpick = hotpickId != null && hotpickId.equals(row.id());
+        return new ActivitySummaryResponse(
+            row.id(),
+            row.title(),
+            row.category(),
+            row.capacity(),
+            row.currentParticipants(),
+            row.isLiked(),
+            row.likeCount(),
+            row.schedule(),
+            row.thumbnail(),
+            isHotpick
+        );
+    }
+}

--- a/src/main/java/com/awp/mgw/activity/service/ActivityQueryService.java
+++ b/src/main/java/com/awp/mgw/activity/service/ActivityQueryService.java
@@ -28,25 +28,30 @@ public class ActivityQueryService implements GetActivityListUseCase, GetActivity
 
     @Override
     public ActivityListResponse getActivityList(Long memberId, String category, String scope, Long cursor) {
+        validateScopeMemberId(scope, memberId);
+
+        ActivityQueryRepository.ActivitySummaryRow hotpickRow = activityQueryRepository.findTopHotpick(memberId, null);
+        Long hotpickId = hotpickRow == null ? null : hotpickRow.id();
+        ActivitySummaryResponse hotpick = mapSummary(hotpickRow, hotpickId);
+
+        if ("hotpick".equalsIgnoreCase(scope)) {
+            List<ActivitySummaryResponse> onlyHotpick = hotpick == null ? List.of() : List.of(hotpick);
+            return new ActivityListResponse(hotpick, onlyHotpick, null);
+        }
+
         List<ActivityQueryRepository.ActivitySummaryRow> rows =
             activityQueryRepository.findActivitySummaries(memberId, category, scope, cursor, PAGE_SIZE + 1);
 
         boolean hasNext = rows.size() > PAGE_SIZE;
         List<ActivityQueryRepository.ActivitySummaryRow> pagedRows = hasNext ? rows.subList(0, PAGE_SIZE) : rows;
 
-        ActivitySummaryResponse hotpick = null;
-        if (scope == null || scope.isBlank()) {
-            ActivityQueryRepository.ActivitySummaryRow hotpickRow = activityQueryRepository.findTopHotpick(memberId, category);
-            hotpick = mapSummary(hotpickRow, hotpickRow != null ? hotpickRow.id() : null);
-        }
-
-        Long hotpickId = hotpick == null ? null : hotpick.id();
         List<ActivitySummaryResponse> activities = pagedRows.stream()
             .map(row -> mapSummary(row, hotpickId))
             .toList();
 
         String nextCursor = hasNext ? String.valueOf(pagedRows.get(pagedRows.size() - 1).id()) : null;
-        return new ActivityListResponse(hotpick, activities, nextCursor);
+        ActivitySummaryResponse responseHotpick = (scope == null || scope.isBlank()) ? hotpick : null;
+        return new ActivityListResponse(responseHotpick, activities, nextCursor);
     }
 
     @Override
@@ -62,6 +67,7 @@ public class ActivityQueryService implements GetActivityListUseCase, GetActivity
         ActivityQueryRepository.ActivitySummaryRow hotpickRow = activityQueryRepository.findTopHotpick(memberId, null);
         Long hotpickId = hotpickRow == null ? null : hotpickRow.id();
         boolean isHotpick = hotpickId != null && hotpickId.equals(activityId);
+        boolean canViewOpenChat = memberId != null && activityQueryRepository.existsJoinedMember(activityId, memberId);
 
         List<ActivityDetailResponse.ActivityMemberResponse> members = activityQueryRepository.findParticipants(activityId).stream()
             .map(participant -> new ActivityDetailResponse.ActivityMemberResponse(
@@ -84,8 +90,18 @@ public class ActivityQueryService implements GetActivityListUseCase, GetActivity
             isHotpick,
             activity.getDescription(),
             members,
-            activity.getOpenchatUrl()
+            canViewOpenChat ? activity.getOpenchatUrl() : null
         );
+    }
+
+    private void validateScopeMemberId(String scope, Long memberId) {
+        if (scope == null || scope.isBlank()) {
+            return;
+        }
+
+        if (("joined".equalsIgnoreCase(scope) || "created".equalsIgnoreCase(scope)) && memberId == null) {
+            throw new ActivityDomainException(ActivityErrorCode.MEMBER_ID_REQUIRED_FOR_SCOPE);
+        }
     }
 
     private ActivitySummaryResponse mapSummary(ActivityQueryRepository.ActivitySummaryRow row, Long hotpickId) {

--- a/src/main/java/com/awp/mgw/activity/usecase/GetActivityDetailUseCase.java
+++ b/src/main/java/com/awp/mgw/activity/usecase/GetActivityDetailUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.activity.usecase;
+
+import com.awp.mgw.activity.controller.dto.response.ActivityDetailResponse;
+
+public interface GetActivityDetailUseCase {
+    ActivityDetailResponse getActivityDetail(Long memberId, Long activityId);
+}

--- a/src/main/java/com/awp/mgw/activity/usecase/GetActivityListUseCase.java
+++ b/src/main/java/com/awp/mgw/activity/usecase/GetActivityListUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.activity.usecase;
+
+import com.awp.mgw.activity.controller.dto.response.ActivityListResponse;
+
+public interface GetActivityListUseCase {
+    ActivityListResponse getActivityList(Long memberId, String category, String scope, Long cursor);
+}

--- a/src/main/java/com/awp/mgw/activity/usecase/JoinActivityUseCase.java
+++ b/src/main/java/com/awp/mgw/activity/usecase/JoinActivityUseCase.java
@@ -1,0 +1,8 @@
+package com.awp.mgw.activity.usecase;
+
+import com.awp.mgw.activity.controller.dto.request.JoinActivityRequest;
+import com.awp.mgw.activity.controller.dto.response.ActivityIdResponse;
+
+public interface JoinActivityUseCase {
+    ActivityIdResponse joinActivity(Long memberId, Long activityId, JoinActivityRequest request);
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #

## 🚀 작업 내용

> Issue에 적힌 내용과 더불어, 작업한 내용을 설명해주세요.

<img width="1399" height="570" alt="image" src="https://github.com/user-attachments/assets/8f247d2a-2ecb-469c-a605-2dfdf70b4151" />

- 활동 참여
------

<img width="1404" height="817" alt="image" src="https://github.com/user-attachments/assets/0ee65cee-faae-47b1-bca4-f872367a9010" />

- 활동 통합 조회
------

<img width="1407" height="821" alt="image" src="https://github.com/user-attachments/assets/ecc23550-d66b-4a8c-99f2-f6d716b37e75" />

- 활동 상세 조회
------

## 💬 리뷰 중점사항

> 마찬가지로 상세한 에러는 나중에 가면서 디벨롭 할 예정입니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 활동 목록 조회 기능 추가 (필터링, 커서 기반 페이지네이션 포함)
  * 활동 상세 정보 조회 기능 추가 (참여자 목록, 좋아요 정보 포함)
  * 활동 참여 기능 추가 (개인 참여 또는 그룹 참여 선택 가능)

* **개선사항**
  * 활동 정원 초과 시 오류 처리 추가
  * 중복 참여 방지 기능 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GCU-makeGroup/MGW-server/pull/23)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->