### PR TITLE
Feat/#22 그룹 참여

### DIFF
--- a/src/main/java/com/awp/mgw/group/controller/GroupController.java
+++ b/src/main/java/com/awp/mgw/group/controller/GroupController.java
@@ -5,6 +5,7 @@ import com.awp.mgw.group.controller.dto.response.CreateGroupResponse;
 import com.awp.mgw.group.controller.dto.response.GetGroupDetailResponse;
 import com.awp.mgw.group.controller.dto.response.GetGroupListResponse;
 import com.awp.mgw.group.usecase.command.CreateGroupUseCase;
+import com.awp.mgw.group.usecase.command.JoinGroupUseCase;
 import com.awp.mgw.group.usecase.command.UpdateGroupUseCase;
 import com.awp.mgw.group.usecase.query.GetGroupDetailUseCase;
 import com.awp.mgw.group.usecase.query.GetGroupListUseCase;
@@ -26,6 +27,7 @@ public class GroupController {
 
     private final CreateGroupUseCase createGroupUseCase;
     private final UpdateGroupUseCase updateGroupUseCase;
+    private final JoinGroupUseCase joinGroupUseCase;
     private final GetGroupListUseCase getGroupListUseCase;
     private final GetGroupDetailUseCase getGroupDetailUseCase;
 
@@ -62,5 +64,13 @@ public class GroupController {
             @PathVariable Long groupId
     ) {
         return getGroupDetailUseCase.getGroupDetail(memberId, groupId);
+    }
+
+    @PostMapping("/{groupId}/members/me")
+    public void joinGroup(
+            @RequestParam Long memberId,
+            @PathVariable Long groupId
+    ) {
+        joinGroupUseCase.joinGroup(memberId, groupId);
     }
 }

--- a/src/main/java/com/awp/mgw/group/domain/exception/GroupErrorCode.java
+++ b/src/main/java/com/awp/mgw/group/domain/exception/GroupErrorCode.java
@@ -26,6 +26,8 @@ public enum GroupErrorCode implements BaseCode {
     COMMENT_NOT_OWNED(HttpStatus.FORBIDDEN, "GROUP-013", "본인의 댓글만 수정/삭제할 수 있습니다."),
     INVALID_COMMENT_CONTENT(HttpStatus.BAD_REQUEST, "GROUP-014", "댓글 내용이 유효하지 않습니다."),
     INVALID_COMMENT_PARENT(HttpStatus.BAD_REQUEST, "GROUP-015", "부모 댓글 정보가 유효하지 않습니다."),
+    GROUP_CAPACITY_EXCEEDED(HttpStatus.CONFLICT, "GROUP-016", "그룹 정원이 초과되었습니다."),
+    PRIVATE_GROUP_CANNOT_JOIN(HttpStatus.FORBIDDEN, "GROUP-017", "비공개 그룹은 바로 참여할 수 없습니다."),
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/awp/mgw/group/port/GroupMemberRepository.java
+++ b/src/main/java/com/awp/mgw/group/port/GroupMemberRepository.java
@@ -4,4 +4,7 @@ import com.awp.mgw.group.domain.GroupMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+    boolean existsByMember_IdAndGroup_Id(Long memberId, Long groupId);
+
+    long countByGroup_Id(Long groupId);
 }

--- a/src/main/java/com/awp/mgw/group/port/GroupRepository.java
+++ b/src/main/java/com/awp/mgw/group/port/GroupRepository.java
@@ -1,11 +1,20 @@
 package com.awp.mgw.group.port;
 
 import com.awp.mgw.group.domain.Group;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 /**
  * 단순 CRUD 용 레포지토리
  */
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT g FROM Group g WHERE g.id = :groupId")
+    Optional<Group> findByIdForUpdate(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/awp/mgw/group/service/GroupCommandService.java
+++ b/src/main/java/com/awp/mgw/group/service/GroupCommandService.java
@@ -15,6 +15,7 @@ import com.awp.mgw.group.port.GroupCategoryRepository;
 import com.awp.mgw.group.port.GroupMemberRepository;
 import com.awp.mgw.group.port.GroupRepository;
 import com.awp.mgw.group.usecase.command.CreateGroupUseCase;
+import com.awp.mgw.group.usecase.command.JoinGroupUseCase;
 import com.awp.mgw.group.usecase.command.UpdateGroupUseCase;
 import com.awp.mgw.member.domain.Member;
 import com.awp.mgw.member.domain.exception.MemberDomainException;
@@ -29,7 +30,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class GroupCommandService implements CreateGroupUseCase, UpdateGroupUseCase {
+public class GroupCommandService implements CreateGroupUseCase, UpdateGroupUseCase, JoinGroupUseCase {
 
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
@@ -88,6 +89,28 @@ public class GroupCommandService implements CreateGroupUseCase, UpdateGroupUseCa
         );
 
         return CreateGroupResponse.from(group.getId());
+    }
+
+    @Override
+    public void joinGroup(Long memberId, Long groupId) {
+        Member member = getMemberOrThrow(memberId);
+        Group group = groupRepository.findByIdForUpdate(groupId)
+                .orElseThrow(() -> new GroupDomainException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        if (!group.getIsPublic()) {
+            throw new GroupDomainException(GroupErrorCode.PRIVATE_GROUP_CANNOT_JOIN);
+        }
+
+        if (groupMemberRepository.existsByMember_IdAndGroup_Id(member.getId(), group.getId())) {
+            throw new GroupDomainException(GroupErrorCode.MEMBER_ALREADY_JOINED_GROUP);
+        }
+
+        long currentMemberCount = groupMemberRepository.countByGroup_Id(group.getId());
+        if (currentMemberCount >= group.getCapacity()) {
+            throw new GroupDomainException(GroupErrorCode.GROUP_CAPACITY_EXCEEDED);
+        }
+
+        groupMemberRepository.save(GroupMember.create(member, group));
     }
 
     /**

--- a/src/main/java/com/awp/mgw/group/usecase/command/JoinGroupUseCase.java
+++ b/src/main/java/com/awp/mgw/group/usecase/command/JoinGroupUseCase.java
@@ -1,0 +1,5 @@
+package com.awp.mgw.group.usecase.command;
+
+public interface JoinGroupUseCase {
+    void joinGroup(Long memberId, Long groupId);
+}

--- a/src/test/java/com/awp/mgw/group/service/GroupCommandServiceTest.java
+++ b/src/test/java/com/awp/mgw/group/service/GroupCommandServiceTest.java
@@ -1,0 +1,118 @@
+package com.awp.mgw.group.service;
+
+import com.awp.mgw.category.port.CategoryRepository;
+import com.awp.mgw.group.domain.Group;
+import com.awp.mgw.group.domain.GroupMember;
+import com.awp.mgw.group.domain.exception.GroupDomainException;
+import com.awp.mgw.group.domain.exception.GroupErrorCode;
+import com.awp.mgw.group.port.GroupCategoryRepository;
+import com.awp.mgw.group.port.GroupMemberRepository;
+import com.awp.mgw.group.port.GroupRepository;
+import com.awp.mgw.member.domain.Member;
+import com.awp.mgw.member.port.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GroupCommandServiceTest {
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+
+    @Mock
+    private GroupCategoryRepository groupCategoryRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private GroupCommandService groupCommandService;
+
+    @Test
+    void joinGroupSavesMemberWhenGroupHasCapacity() {
+        Member member = member(2L);
+        Group group = group(10L, member(1L), true, 3);
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(groupRepository.findByIdForUpdate(group.getId())).thenReturn(Optional.of(group));
+        when(groupMemberRepository.existsByMember_IdAndGroup_Id(member.getId(), group.getId())).thenReturn(false);
+        when(groupMemberRepository.countByGroup_Id(group.getId())).thenReturn(2L);
+
+        groupCommandService.joinGroup(member.getId(), group.getId());
+
+        verify(groupMemberRepository).save(org.mockito.ArgumentMatchers.any(GroupMember.class));
+    }
+
+    @Test
+    void joinGroupThrowsWhenAlreadyJoined() {
+        Member member = member(2L);
+        Group group = group(10L, member(1L), true, 3);
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(groupRepository.findByIdForUpdate(group.getId())).thenReturn(Optional.of(group));
+        when(groupMemberRepository.existsByMember_IdAndGroup_Id(member.getId(), group.getId())).thenReturn(true);
+
+        assertThatThrownBy(() -> groupCommandService.joinGroup(member.getId(), group.getId()))
+                .isInstanceOf(GroupDomainException.class)
+                .hasMessage(GroupErrorCode.MEMBER_ALREADY_JOINED_GROUP.getMessage());
+
+        verify(groupMemberRepository, never()).save(org.mockito.ArgumentMatchers.any(GroupMember.class));
+    }
+
+    @Test
+    void joinGroupThrowsWhenGroupIsFull() {
+        Member member = member(2L);
+        Group group = group(10L, member(1L), true, 3);
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(groupRepository.findByIdForUpdate(group.getId())).thenReturn(Optional.of(group));
+        when(groupMemberRepository.existsByMember_IdAndGroup_Id(member.getId(), group.getId())).thenReturn(false);
+        when(groupMemberRepository.countByGroup_Id(group.getId())).thenReturn(3L);
+
+        assertThatThrownBy(() -> groupCommandService.joinGroup(member.getId(), group.getId()))
+                .isInstanceOf(GroupDomainException.class)
+                .hasMessage(GroupErrorCode.GROUP_CAPACITY_EXCEEDED.getMessage());
+
+        verify(groupMemberRepository, never()).save(org.mockito.ArgumentMatchers.any(GroupMember.class));
+    }
+
+    @Test
+    void joinGroupThrowsWhenGroupIsPrivate() {
+        Member member = member(2L);
+        Group group = group(10L, member(1L), false, 3);
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(groupRepository.findByIdForUpdate(group.getId())).thenReturn(Optional.of(group));
+
+        assertThatThrownBy(() -> groupCommandService.joinGroup(member.getId(), group.getId()))
+                .isInstanceOf(GroupDomainException.class)
+                .hasMessage(GroupErrorCode.PRIVATE_GROUP_CANNOT_JOIN.getMessage());
+
+        verify(groupMemberRepository, never()).save(org.mockito.ArgumentMatchers.any(GroupMember.class));
+    }
+
+    private Member member(Long id) {
+        Member member = Member.create("member" + id + "@test.com", "member" + id, null, null);
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    private Group group(Long id, Member owner, boolean isPublic, int capacity) {
+        Group group = Group.create("group", "title", "content", owner, null, isPublic, capacity);
+        ReflectionTestUtils.setField(group, "id", id);
+        return group;
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈


- resolves #22 



```md
## 작업 내용

- 그룹 참여 API 추가
- 그룹 참여 시 비즈니스 검증 추가
  - 존재하지 않는 회원/그룹 참여 불가
  - 비공개 그룹 직접 참여 불가
  - 이미 참여한 그룹 중복 참여 불가
  - 현재 참여 인원이 정원 이상이면 참여 불가
- 동시 참여 요청으로 정원을 초과하지 않도록 그룹 조회 시 `PESSIMISTIC_WRITE` 락 적용
- 그룹 참여 API Swagger 주석 추가
- 그룹 참여 비즈니스 로직 단위 테스트 추가

## API

### 그룹 참여

```http
POST /api/v1/groups/{groupId}/members/me?memberId={memberId}
```

### Request

Path Variable -> 추후에 변경

| 이름 | 타입 | 설명 |
| --- | --- | --- |
| groupId | Long | 참여할 그룹 ID |

Query Parameter

| 이름 | 타입 | 설명 |
| --- | --- | --- |
| memberId | Long | 참여 요청 회원 ID |

Request Body 없음

### Response

성공 시 Body 없음

```http
200 OK
```

### Error

| 상황 | 코드 |
| --- | --- |
| 회원이 존재하지 않음 | MEMBER-001 |
| 그룹이 존재하지 않음 | GROUP-001 |
| 이미 참여한 그룹 | GROUP-011 |
| 그룹 정원 초과 | GROUP-017 |
| 비공개 그룹 직접 참여 | GROUP-018 |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 그룹 참여 기능: 사용자가 이제 그룹에 참여할 수 있습니다.
  * 그룹 정원 관리: 정원 초과 시 참여를 제한합니다.
  * 비공개 그룹 보호: 비공개 그룹의 직접 참여를 방지합니다.

* **테스트**
  * 그룹 참여 기능 테스트 커버리지 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GCU-makeGroup/MGW-server/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->