### PR TITLE
Feat/#31 댓글 작성 및 내가 속한 그룹 조회

### DIFF
--- a/src/main/java/com/awp/mgw/activity/controller/ActivityController.java
+++ b/src/main/java/com/awp/mgw/activity/controller/ActivityController.java
@@ -134,6 +134,8 @@ public class ActivityController {
         @PathVariable Long activityId
     ) {
         return unlikeActivityUseCase.unlikeActivity(memberId, activityId);
+    }
+
     @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "활동 이미지 업로드", description = "활동 이미지를 업로드하고 저장 경로를 반환합니다.")
     public ActivityImageUploadResponse uploadActivityImage(

--- a/src/main/java/com/awp/mgw/activity/service/ActivityCommandService.java
+++ b/src/main/java/com/awp/mgw/activity/service/ActivityCommandService.java
@@ -189,6 +189,9 @@ public class ActivityCommandService implements
 
         activityLikeRepository.delete(activityLike);
         return ActivityIdResponse.from(activityId);
+    }
+
+    @Override
     public ActivityImageUploadResponse uploadActivityImage(Long memberId, MultipartFile file) {
         getMemberOrThrow(memberId);
         validateImageFile(file);

--- a/src/main/java/com/awp/mgw/group/controller/GroupController.java
+++ b/src/main/java/com/awp/mgw/group/controller/GroupController.java
@@ -1,9 +1,12 @@
 package com.awp.mgw.group.controller;
 
+import com.awp.mgw.group.controller.dto.request.CreateCommentRequest;
 import com.awp.mgw.group.controller.dto.request.CreateGroupRequest;
+import com.awp.mgw.group.controller.dto.response.CreateCommentResponse;
 import com.awp.mgw.group.controller.dto.response.CreateGroupResponse;
 import com.awp.mgw.group.controller.dto.response.GetGroupDetailResponse;
 import com.awp.mgw.group.controller.dto.response.GetGroupListResponse;
+import com.awp.mgw.group.usecase.command.CreateCommentUseCase;
 import com.awp.mgw.group.usecase.command.CreateGroupUseCase;
 import com.awp.mgw.group.usecase.command.DeleteGroupUseCase;
 import com.awp.mgw.group.usecase.command.LeaveGroupUseCase;
@@ -11,6 +14,7 @@ import com.awp.mgw.group.usecase.command.JoinGroupUseCase;
 import com.awp.mgw.group.usecase.command.UpdateGroupUseCase;
 import com.awp.mgw.group.usecase.query.GetGroupDetailUseCase;
 import com.awp.mgw.group.usecase.query.GetGroupListUseCase;
+import com.awp.mgw.group.usecase.query.GetMyGroupListUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,11 +34,13 @@ import java.util.List;
 public class GroupController {
 
     private final CreateGroupUseCase createGroupUseCase;
+    private final CreateCommentUseCase createCommentUseCase;
     private final UpdateGroupUseCase updateGroupUseCase;
     private final JoinGroupUseCase joinGroupUseCase;
     private final DeleteGroupUseCase deleteGroupUseCase;
     private final LeaveGroupUseCase leaveGroupUseCase;
     private final GetGroupListUseCase getGroupListUseCase;
+    private final GetMyGroupListUseCase getMyGroupListUseCase;
     private final GetGroupDetailUseCase getGroupDetailUseCase;
 
     @PostMapping
@@ -82,6 +88,20 @@ public class GroupController {
         return getGroupListUseCase.getGroupList(memberId, categoryIds, pageable);
     }
 
+    @GetMapping("/me")
+    @Operation(
+            summary = "내가 속한 그룹 목록 조회",
+            description = "요청 회원이 group_member로 참여 중인 그룹 목록을 조회합니다. 응답 형식은 그룹 목록 조회와 동일합니다."
+    )
+    public GetGroupListResponse getMyGroupList(
+            @Parameter(description = "조회 요청 회원 ID", example = "1")
+            @RequestParam Long memberId,
+            @Parameter(description = "페이징 및 정렬 정보. 예: sort=createdAt,desc / sort=name,asc / sort=capacity,desc")
+            @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return getMyGroupListUseCase.getMyGroupList(memberId, pageable);
+    }
+
     @GetMapping("/{groupId}")
     @Operation(
             summary = "그룹 상세 조회",
@@ -108,6 +128,21 @@ public class GroupController {
             @PathVariable Long groupId
     ) {
         joinGroupUseCase.joinGroup(memberId, groupId);
+    }
+
+    @PostMapping("/{groupId}/comments")
+    @Operation(
+            summary = "댓글 작성",
+            description = "회원이 그룹에 댓글을 작성합니다. parentId를 전달하면 같은 그룹 댓글의 대댓글로 작성됩니다."
+    )
+    public CreateCommentResponse createComment(
+            @Parameter(description = "댓글 작성 회원 ID", example = "1")
+            @RequestParam Long memberId,
+            @Parameter(description = "댓글을 작성할 그룹 ID", example = "10")
+            @PathVariable Long groupId,
+            @Valid @RequestBody CreateCommentRequest request
+    ) {
+        return createCommentUseCase.createComment(memberId, groupId, request);
     }
 
     @DeleteMapping("/{groupId}")

--- a/src/main/java/com/awp/mgw/group/controller/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/awp/mgw/group/controller/dto/request/CreateCommentRequest.java
@@ -1,0 +1,13 @@
+package com.awp.mgw.group.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateCommentRequest(
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        @Size(max = 1000, message = "댓글 내용은 1000자 이하여야 합니다.")
+        String content,
+
+        Long parentId
+) {
+}

--- a/src/main/java/com/awp/mgw/group/controller/dto/response/CreateCommentResponse.java
+++ b/src/main/java/com/awp/mgw/group/controller/dto/response/CreateCommentResponse.java
@@ -1,0 +1,10 @@
+package com.awp.mgw.group.controller.dto.response;
+
+public record CreateCommentResponse(
+        Long commentId,
+        Boolean authorGroupMember
+) {
+    public static CreateCommentResponse from(Long commentId, Boolean authorGroupMember) {
+        return new CreateCommentResponse(commentId, authorGroupMember);
+    }
+}

--- a/src/main/java/com/awp/mgw/group/controller/dto/response/GetGroupDetailResponse.java
+++ b/src/main/java/com/awp/mgw/group/controller/dto/response/GetGroupDetailResponse.java
@@ -7,6 +7,7 @@ import com.awp.mgw.member.domain.Member;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 public record GetGroupDetailResponse(
         Long id,
@@ -29,7 +30,8 @@ public record GetGroupDetailResponse(
             List<Category> categories,
             Integer currentMemberCount,
             Integer commentCount,
-            List<Comment> comments
+            List<Comment> comments,
+            Set<Long> groupMemberIds
     ) {
         return new GetGroupDetailResponse(
                 group.getId(),
@@ -48,7 +50,7 @@ public record GetGroupDetailResponse(
                 currentMemberCount,
                 commentCount,
                 comments.stream()
-                        .map(CommentInfo::from)
+                        .map(comment -> CommentInfo.from(comment, groupMemberIds))
                         .toList()
         );
     }
@@ -73,15 +75,19 @@ public record GetGroupDetailResponse(
             Long id,
             Long parentId,
             AuthorInfo author,
+            Boolean authorGroupMember,
             String content,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
-        public static CommentInfo from(Comment comment) {
+        public static CommentInfo from(Comment comment, Set<Long> groupMemberIds) {
+            Member author = comment.getMember();
+
             return new CommentInfo(
                     comment.getId(),
                     comment.getParent() != null ? comment.getParent().getId() : null,
-                    AuthorInfo.from(comment.getMember()),
+                    AuthorInfo.from(author),
+                    author != null && groupMemberIds.contains(author.getId()),
                     comment.getContent(),
                     comment.getCreatedAt(),
                     comment.getUpdatedAt()

--- a/src/main/java/com/awp/mgw/group/port/GroupQueryRepository.java
+++ b/src/main/java/com/awp/mgw/group/port/GroupQueryRepository.java
@@ -20,6 +20,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.awp.mgw.category.domain.QCategory.category;
 import static com.awp.mgw.group.domain.QComment.comment;
@@ -69,6 +71,38 @@ public class GroupQueryRepository {
                 .selectFrom(group)
                 .distinct()
                 .where(group.id.in(groupIds), accessibleGroup(memberId))
+                .orderBy(orderSpecifiers)
+                .fetch();
+
+        return new PageImpl<>(groups, pageable, total != null ? total : 0);
+    }
+
+    public Page<Group> findMyGroupList(Long memberId, Pageable pageable) {
+        OrderSpecifier<?>[] orderSpecifiers = toOrderSpecifiers(pageable.getSort());
+
+        List<Long> groupIds = queryFactory
+                .select(group.id)
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .where(groupMember.member.id.eq(memberId))
+                .orderBy(orderSpecifiers)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(groupMember.id.count())
+                .from(groupMember)
+                .where(groupMember.member.id.eq(memberId))
+                .fetchOne();
+
+        if (groupIds.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, total != null ? total : 0);
+        }
+
+        List<Group> groups = queryFactory
+                .selectFrom(group)
+                .where(group.id.in(groupIds))
                 .orderBy(orderSpecifiers)
                 .fetch();
 
@@ -141,6 +175,16 @@ public class GroupQueryRepository {
         });
 
         return currentMemberCountByGroupId;
+    }
+
+    public Set<Long> findGroupMemberIdsByGroupId(Long groupId) {
+        return queryFactory
+                .select(groupMember.member.id)
+                .from(groupMember)
+                .where(groupMember.group.id.eq(groupId))
+                .fetch()
+                .stream()
+                .collect(Collectors.toSet());
     }
 
     private BooleanExpression categoryIdIn(List<Long> categoryIds) {

--- a/src/main/java/com/awp/mgw/group/service/GroupCommandService.java
+++ b/src/main/java/com/awp/mgw/group/service/GroupCommandService.java
@@ -5,16 +5,21 @@ import com.awp.mgw.category.domain.Category;
 import com.awp.mgw.category.domain.exception.CategoryDomainException;
 import com.awp.mgw.category.domain.exception.CategoryErrorCode;
 import com.awp.mgw.category.port.CategoryRepository;
+import com.awp.mgw.group.controller.dto.request.CreateCommentRequest;
 import com.awp.mgw.group.controller.dto.request.CreateGroupRequest;
+import com.awp.mgw.group.controller.dto.response.CreateCommentResponse;
 import com.awp.mgw.group.controller.dto.response.CreateGroupResponse;
+import com.awp.mgw.group.domain.Comment;
 import com.awp.mgw.group.domain.Group;
 import com.awp.mgw.group.domain.GroupCategory;
 import com.awp.mgw.group.domain.GroupMember;
 import com.awp.mgw.group.domain.exception.GroupDomainException;
 import com.awp.mgw.group.domain.exception.GroupErrorCode;
+import com.awp.mgw.group.port.CommentRepository;
 import com.awp.mgw.group.port.GroupCategoryRepository;
 import com.awp.mgw.group.port.GroupMemberRepository;
 import com.awp.mgw.group.port.GroupRepository;
+import com.awp.mgw.group.usecase.command.CreateCommentUseCase;
 import com.awp.mgw.group.usecase.command.CreateGroupUseCase;
 import com.awp.mgw.group.usecase.command.DeleteGroupUseCase;
 import com.awp.mgw.group.usecase.command.LeaveGroupUseCase;
@@ -33,9 +38,10 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class GroupCommandService implements CreateGroupUseCase, UpdateGroupUseCase, JoinGroupUseCase, DeleteGroupUseCase, LeaveGroupUseCase {
+public class GroupCommandService implements CreateGroupUseCase, CreateCommentUseCase, UpdateGroupUseCase, JoinGroupUseCase, DeleteGroupUseCase, LeaveGroupUseCase {
 
     private final GroupRepository groupRepository;
+    private final CommentRepository commentRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final GroupCategoryRepository groupCategoryRepository;
     private final ActivityGroupRepository activityGroupRepository;
@@ -143,6 +149,18 @@ public class GroupCommandService implements CreateGroupUseCase, UpdateGroupUseCa
         groupMemberRepository.save(GroupMember.create(member, group));
     }
 
+    @Override
+    public CreateCommentResponse createComment(Long memberId, Long groupId, CreateCommentRequest request) {
+        Member member = getMemberOrThrow(memberId);
+        Group group = getGroupOrThrow(groupId);
+
+        Comment parent = getParentCommentOrNull(request.parentId(), group.getId());
+        Comment savedComment = commentRepository.save(Comment.create(group, member, parent, request.content()));
+        boolean authorGroupMember = groupMemberRepository.existsByMember_IdAndGroup_Id(member.getId(), group.getId());
+
+        return CreateCommentResponse.from(savedComment.getId(), authorGroupMember);
+    }
+
     /**
      * 그룹 정원 유효성 검증
      */
@@ -185,6 +203,21 @@ public class GroupCommandService implements CreateGroupUseCase, UpdateGroupUseCa
         if (currentMemberCount > 1) {
             throw new GroupDomainException(GroupErrorCode.GROUP_OWNER_CANNOT_LEAVE);
         }
+    }
+
+    private Comment getParentCommentOrNull(Long parentId, Long groupId) {
+        if (parentId == null) {
+            return null;
+        }
+
+        Comment parent = commentRepository.findById(parentId)
+                .orElseThrow(() -> new GroupDomainException(GroupErrorCode.COMMENT_NOT_FOUND));
+
+        if (!parent.getGroup().getId().equals(groupId)) {
+            throw new GroupDomainException(GroupErrorCode.INVALID_COMMENT_PARENT);
+        }
+
+        return parent;
     }
 
     private List<Category> getCategoriesOrThrow(List<Long> categoryIds) {

--- a/src/main/java/com/awp/mgw/group/service/GroupQueryService.java
+++ b/src/main/java/com/awp/mgw/group/service/GroupQueryService.java
@@ -11,6 +11,7 @@ import com.awp.mgw.group.port.CommentRepository;
 import com.awp.mgw.group.port.GroupQueryRepository;
 import com.awp.mgw.group.usecase.query.GetGroupDetailUseCase;
 import com.awp.mgw.group.usecase.query.GetGroupListUseCase;
+import com.awp.mgw.group.usecase.query.GetMyGroupListUseCase;
 import com.awp.mgw.member.domain.Member;
 import com.awp.mgw.member.domain.exception.MemberDomainException;
 import com.awp.mgw.member.domain.exception.MemberErrorCode;
@@ -24,12 +25,13 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class GroupQueryService implements GetGroupListUseCase, GetGroupDetailUseCase {
+public class GroupQueryService implements GetGroupListUseCase, GetMyGroupListUseCase, GetGroupDetailUseCase {
 
     private final GroupQueryRepository groupQueryRepository;
     private final CommentRepository commentRepository;
@@ -39,18 +41,18 @@ public class GroupQueryService implements GetGroupListUseCase, GetGroupDetailUse
     public GetGroupListResponse getGroupList(Long memberId, List<Long> categoryIds, Pageable pageable) {
         getMemberOrThrow(memberId);
 
-        // 목록 대상 그룹만 먼저 가져온 뒤, 댓글 수와 카테고리는 groupId 기준 Map으로 한 번에 붙임
         Page<Group> groupPage = groupQueryRepository.findGroupList(memberId, categoryIds, pageable);
-        Map<Long, Integer> commentCountByGroupId = getCommentCountByGroupId(groupPage.getContent());
-        Map<Long, Integer> currentMemberCountByGroupId = getCurrentMemberCountByGroupId(groupPage.getContent());
-        Map<Long, List<Category>> categoriesByGroupId = getCategoriesByGroupId(groupPage.getContent());
 
-        return GetGroupListResponse.from(
-                groupPage,
-                commentCountByGroupId,
-                currentMemberCountByGroupId,
-                categoriesByGroupId
-        );
+        return toGroupListResponse(groupPage);
+    }
+
+    @Override
+    public GetGroupListResponse getMyGroupList(Long memberId, Pageable pageable) {
+        getMemberOrThrow(memberId);
+
+        Page<Group> groupPage = groupQueryRepository.findMyGroupList(memberId, pageable);
+
+        return toGroupListResponse(groupPage);
     }
 
     @Override
@@ -67,13 +69,28 @@ public class GroupQueryService implements GetGroupListUseCase, GetGroupDetailUse
         Integer commentCount = getCommentCountByGroupId(List.of(group))
                 .getOrDefault(groupId, 0);
         List<Comment> comments = groupQueryRepository.findCommentsByGroupId(groupId);
+        Set<Long> groupMemberIds = groupQueryRepository.findGroupMemberIdsByGroupId(groupId);
 
-        return GetGroupDetailResponse.from(group, categories, currentMemberCount, commentCount, comments);
+        return GetGroupDetailResponse.from(group, categories, currentMemberCount, commentCount, comments, groupMemberIds);
     }
 
     private Member getMemberOrThrow(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberDomainException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private GetGroupListResponse toGroupListResponse(Page<Group> groupPage) {
+        // 목록 대상 그룹만 먼저 가져온 뒤, 댓글 수와 카테고리는 groupId 기준 Map으로 한 번에 붙임
+        Map<Long, Integer> commentCountByGroupId = getCommentCountByGroupId(groupPage.getContent());
+        Map<Long, Integer> currentMemberCountByGroupId = getCurrentMemberCountByGroupId(groupPage.getContent());
+        Map<Long, List<Category>> categoriesByGroupId = getCategoriesByGroupId(groupPage.getContent());
+
+        return GetGroupListResponse.from(
+                groupPage,
+                commentCountByGroupId,
+                currentMemberCountByGroupId,
+                categoriesByGroupId
+        );
     }
 
     private Map<Long, Integer> getCommentCountByGroupId(List<Group> groups) {

--- a/src/main/java/com/awp/mgw/group/usecase/command/CreateCommentUseCase.java
+++ b/src/main/java/com/awp/mgw/group/usecase/command/CreateCommentUseCase.java
@@ -1,0 +1,8 @@
+package com.awp.mgw.group.usecase.command;
+
+import com.awp.mgw.group.controller.dto.request.CreateCommentRequest;
+import com.awp.mgw.group.controller.dto.response.CreateCommentResponse;
+
+public interface CreateCommentUseCase {
+    CreateCommentResponse createComment(Long memberId, Long groupId, CreateCommentRequest request);
+}

--- a/src/main/java/com/awp/mgw/group/usecase/query/GetMyGroupListUseCase.java
+++ b/src/main/java/com/awp/mgw/group/usecase/query/GetMyGroupListUseCase.java
@@ -1,0 +1,8 @@
+package com.awp.mgw.group.usecase.query;
+
+import com.awp.mgw.group.controller.dto.response.GetGroupListResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface GetMyGroupListUseCase {
+    GetGroupListResponse getMyGroupList(Long memberId, Pageable pageable);
+}

--- a/src/test/java/com/awp/mgw/group/service/GroupCommandServiceTest.java
+++ b/src/test/java/com/awp/mgw/group/service/GroupCommandServiceTest.java
@@ -2,10 +2,14 @@ package com.awp.mgw.group.service;
 
 import com.awp.mgw.activity.port.ActivityGroupRepository;
 import com.awp.mgw.category.port.CategoryRepository;
+import com.awp.mgw.group.controller.dto.request.CreateCommentRequest;
+import com.awp.mgw.group.controller.dto.response.CreateCommentResponse;
+import com.awp.mgw.group.domain.Comment;
 import com.awp.mgw.group.domain.Group;
 import com.awp.mgw.group.domain.GroupMember;
 import com.awp.mgw.group.domain.exception.GroupDomainException;
 import com.awp.mgw.group.domain.exception.GroupErrorCode;
+import com.awp.mgw.group.port.CommentRepository;
 import com.awp.mgw.group.port.GroupCategoryRepository;
 import com.awp.mgw.group.port.GroupMemberRepository;
 import com.awp.mgw.group.port.GroupRepository;
@@ -34,6 +38,9 @@ class GroupCommandServiceTest {
     private GroupRepository groupRepository;
 
     @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
     private GroupMemberRepository groupMemberRepository;
 
     @Mock
@@ -50,6 +57,75 @@ class GroupCommandServiceTest {
 
     @InjectMocks
     private GroupCommandService groupCommandService;
+
+    @Test
+    void createCommentAllowsNonGroupMember() {
+        Member member = member(2L);
+        Group group = group(10L, member(1L));
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+        when(groupMemberRepository.existsByMember_IdAndGroup_Id(member.getId(), group.getId())).thenReturn(false);
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment comment = invocation.getArgument(0);
+            ReflectionTestUtils.setField(comment, "id", 100L);
+            return comment;
+        });
+
+        CreateCommentResponse response = groupCommandService.createComment(
+                member.getId(),
+                group.getId(),
+                new CreateCommentRequest("hello", null)
+        );
+
+        verify(commentRepository).save(any(Comment.class));
+        assertThat(response.commentId()).isEqualTo(100L);
+        assertThat(response.authorGroupMember()).isFalse();
+    }
+
+    @Test
+    void createCommentReturnsAuthorGroupMemberWhenWriterBelongsToGroup() {
+        Member member = member(2L);
+        Group group = group(10L, member(1L));
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+        when(groupMemberRepository.existsByMember_IdAndGroup_Id(member.getId(), group.getId())).thenReturn(true);
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment comment = invocation.getArgument(0);
+            ReflectionTestUtils.setField(comment, "id", 101L);
+            return comment;
+        });
+
+        CreateCommentResponse response = groupCommandService.createComment(
+                member.getId(),
+                group.getId(),
+                new CreateCommentRequest("member comment", null)
+        );
+
+        verify(commentRepository).save(any(Comment.class));
+        assertThat(response.commentId()).isEqualTo(101L);
+        assertThat(response.authorGroupMember()).isTrue();
+    }
+
+    @Test
+    void createCommentThrowsWhenParentCommentBelongsToOtherGroup() {
+        Member member = member(2L);
+        Group group = group(10L, member(1L));
+        Group otherGroup = group(20L, member(3L));
+        Comment parent = comment(100L, otherGroup, member);
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(groupRepository.findById(group.getId())).thenReturn(Optional.of(group));
+        when(commentRepository.findById(parent.getId())).thenReturn(Optional.of(parent));
+
+        assertThatThrownBy(() -> groupCommandService.createComment(
+                member.getId(),
+                group.getId(),
+                new CreateCommentRequest("reply", parent.getId())
+        ))
+                .isInstanceOf(GroupDomainException.class)
+                .hasMessage(GroupErrorCode.INVALID_COMMENT_PARENT.getMessage());
+
+        verify(commentRepository, never()).save(any(Comment.class));
+    }
 
     @Test
     void joinGroupSavesMemberWhenGroupHasCapacity() {
@@ -207,7 +283,7 @@ class GroupCommandServiceTest {
     }
 
     private Member member(Long id) {
-        Member member = Member.create("member" + id + "@test.com", "member" + id, null, null);
+        Member member = Member.create("member" + id + "@test.com", "password", "member" + id, null, null);
         ReflectionTestUtils.setField(member, "id", id);
         return member;
     }
@@ -220,5 +296,11 @@ class GroupCommandServiceTest {
         Group group = Group.create("group", "title", "content", owner, null, isPublic, capacity);
         ReflectionTestUtils.setField(group, "id", id);
         return group;
+    }
+
+    private Comment comment(Long id, Group group, Member member) {
+        Comment comment = Comment.create(group, member, null, "content");
+        ReflectionTestUtils.setField(comment, "id", id);
+        return comment;
     }
 }

--- a/src/test/java/com/awp/mgw/group/service/GroupQueryServiceTest.java
+++ b/src/test/java/com/awp/mgw/group/service/GroupQueryServiceTest.java
@@ -1,0 +1,132 @@
+package com.awp.mgw.group.service;
+
+import com.awp.mgw.group.controller.dto.response.GetGroupDetailResponse;
+import com.awp.mgw.group.controller.dto.response.GetGroupListResponse;
+import com.awp.mgw.group.domain.Comment;
+import com.awp.mgw.group.domain.Group;
+import com.awp.mgw.group.port.CommentRepository;
+import com.awp.mgw.group.port.GroupQueryRepository;
+import com.awp.mgw.member.domain.Member;
+import com.awp.mgw.member.port.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GroupQueryServiceTest {
+
+    @Mock
+    private GroupQueryRepository groupQueryRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private GroupQueryService groupQueryService;
+
+    @Test
+    void getGroupDetailReturnsCommentsWithAuthorGroupMemberFlag() {
+        Member requester = member(1L);
+        Member groupMember = member(2L);
+        Member outsideMember = member(3L);
+        Group group = group(10L, requester);
+        Comment memberComment = comment(100L, group, groupMember, null, "member comment");
+        Comment outsideComment = comment(101L, group, outsideMember, memberComment, "outside reply");
+
+        when(memberRepository.findById(requester.getId())).thenReturn(Optional.of(requester));
+        when(groupQueryRepository.findAccessibleGroupDetailById(group.getId(), requester.getId()))
+                .thenReturn(Optional.of(group));
+        when(groupQueryRepository.findCategoriesByGroupIds(List.of(group.getId()))).thenReturn(Map.of());
+        when(groupQueryRepository.findCurrentMemberCountsByGroupIds(List.of(group.getId())))
+                .thenReturn(Map.of(group.getId(), 2));
+        when(commentRepository.countCommentsByGroupIds(List.of(group.getId()))).thenReturn(List.of(commentCount(group.getId(), 2L)));
+        when(groupQueryRepository.findCommentsByGroupId(group.getId()))
+                .thenReturn(List.of(memberComment, outsideComment));
+        when(groupQueryRepository.findGroupMemberIdsByGroupId(group.getId()))
+                .thenReturn(Set.of(requester.getId(), groupMember.getId()));
+
+        GetGroupDetailResponse response = groupQueryService.getGroupDetail(requester.getId(), group.getId());
+
+        assertThat(response.comments()).hasSize(2);
+        assertThat(response.comments().get(0).id()).isEqualTo(memberComment.getId());
+        assertThat(response.comments().get(0).authorGroupMember()).isTrue();
+        assertThat(response.comments().get(1).id()).isEqualTo(outsideComment.getId());
+        assertThat(response.comments().get(1).parentId()).isEqualTo(memberComment.getId());
+        assertThat(response.comments().get(1).authorGroupMember()).isFalse();
+        assertThat(response.commentCount()).isEqualTo(2);
+        assertThat(response.currentMemberCount()).isEqualTo(2);
+    }
+
+    @Test
+    void getMyGroupListReturnsGroupListResponse() {
+        Member requester = member(1L);
+        Group group = group(10L, requester);
+        Pageable pageable = PageRequest.of(0, 10);
+        when(memberRepository.findById(requester.getId())).thenReturn(Optional.of(requester));
+        when(groupQueryRepository.findMyGroupList(requester.getId(), pageable))
+                .thenReturn(new PageImpl<>(List.of(group), pageable, 1));
+        when(commentRepository.countCommentsByGroupIds(List.of(group.getId()))).thenReturn(List.of(commentCount(group.getId(), 3L)));
+        when(groupQueryRepository.findCurrentMemberCountsByGroupIds(List.of(group.getId())))
+                .thenReturn(Map.of(group.getId(), 2));
+        when(groupQueryRepository.findCategoriesByGroupIds(List.of(group.getId()))).thenReturn(Map.of());
+
+        GetGroupListResponse response = groupQueryService.getMyGroupList(requester.getId(), pageable);
+
+        verify(groupQueryRepository).findMyGroupList(requester.getId(), pageable);
+        assertThat(response.pageInfo().totalElements()).isEqualTo(1);
+        assertThat(response.groups()).hasSize(1);
+        assertThat(response.groups().get(0).id()).isEqualTo(group.getId());
+        assertThat(response.groups().get(0).commentCount()).isEqualTo(3);
+        assertThat(response.groups().get(0).currentMemberCount()).isEqualTo(2);
+    }
+
+    private Member member(Long id) {
+        Member member = Member.create("member" + id + "@test.com", "password", "member" + id, null, null);
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    private Group group(Long id, Member owner) {
+        Group group = Group.create("group", "title", "content", owner, null, true, 10);
+        ReflectionTestUtils.setField(group, "id", id);
+        return group;
+    }
+
+    private Comment comment(Long id, Group group, Member member, Comment parent, String content) {
+        Comment comment = Comment.create(group, member, parent, content);
+        ReflectionTestUtils.setField(comment, "id", id);
+        return comment;
+    }
+
+    private CommentRepository.CommentCountProjection commentCount(Long groupId, Long commentCount) {
+        return new CommentRepository.CommentCountProjection() {
+            @Override
+            public Long getGroupId() {
+                return groupId;
+            }
+
+            @Override
+            public Long getCommentCount() {
+                return commentCount;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [ ] 병합 대상 브랜치가 올바른지 확인해주세요. (Production: `main`, Development: `develop`)
- [ ] PR 제목을 컨벤션에 맞게 작성했는지 확인해주세요. (대괄호 속 태그, 간결한 설명, 특수문자 금지 등)

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #31 

## 🚀 작업 내용


진행한 것:
- 댓글 작성 API 추가
- 내가 속한 그룹 목록 조회 API 추가
- 내가 속한 그룹 목록은 기존 `GetGroupListResponse` DTO 재사용
- 댓글은 그룹 멤버가 아니어도 작성 가능
- 댓글 응답에는 작성자가 해당 그룹 멤버인지 여부를 `authorGroupMember`로 표시
- 대댓글 작성 시 `parentId`가 같은 그룹의 댓글인지 검증
- 전체 빌드를 막던 activity 쪽 병합 괄호 오류도 같이 수정

추가 API:

```http
POST /api/v1/groups/{groupId}/comments?memberId={memberId}
```

Request:
```json
{
  "content": "댓글 내용",
  "parentId": null
}
```

Response:
```json
{
  "commentId": 1,
  "authorGroupMember": true
}
```

```http
GET /api/v1/groups/me?memberId={memberId}&page=0&size=10&sort=updatedAt,desc
```

Response: 기존 그룹 목록 조회와 동일한 `GetGroupListResponse`

댓글 상세 조회 응답의 댓글 항목에도 추가:
```json
{
  "id": 1,
  "parentId": null,
  "author": {
    "id": 2,
    "name": "member2",
    "imageUrl": null
  },
  "authorGroupMember": false,
  "content": "댓글 내용",
  "createdAt": "2026-05-11T10:00:00",
  "updatedAt": "2026-05-11T10:00:00"
}
```



## API
- POST /api/v1/groups/{groupId}/comments?memberId={memberId}
- GET /api/v1/groups/me?memberId={memberId}



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자의 그룹 목록 조회 기능 추가
  * 그룹 내 댓글 작성 기능 추가 (대댓글 지원)
  * 댓글 작성자의 그룹 멤버 여부 표시

* **Tests**
  * 댓글 생성 및 그룹 조회 기능에 대한 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GCU-makeGroup/MGW-server/pull/32)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->