### PR TITLE
Feat/#40 활동 검색 및 limit 추가

### DIFF
--- a/src/main/java/com/awp/mgw/activity/controller/ActivityController.java
+++ b/src/main/java/com/awp/mgw/activity/controller/ActivityController.java
@@ -14,6 +14,7 @@ import com.awp.mgw.activity.usecase.GetActivityListUseCase;
 import com.awp.mgw.activity.usecase.JoinActivityUseCase;
 import com.awp.mgw.activity.usecase.LeaveActivityUseCase;
 import com.awp.mgw.activity.usecase.LikeActivityUseCase;
+import com.awp.mgw.activity.usecase.SearchActivityUseCase;
 import com.awp.mgw.activity.usecase.UnlikeActivityUseCase;
 import com.awp.mgw.activity.usecase.UploadActivityImageUseCase;
 import com.awp.mgw.activity.usecase.UpdateActivityUseCase;
@@ -50,6 +51,7 @@ public class ActivityController {
     private final LeaveActivityUseCase leaveActivityUseCase;
     private final LikeActivityUseCase likeActivityUseCase;
     private final UnlikeActivityUseCase unlikeActivityUseCase;
+    private final SearchActivityUseCase searchActivityUseCase;
     private final UploadActivityImageUseCase uploadActivityImageUseCase;
 
     @PostMapping
@@ -86,9 +88,21 @@ public class ActivityController {
             @AuthenticationPrincipal Long memberId,
             @RequestParam(required = false) String category,
             @RequestParam(required = false) String scope,
+            @RequestParam(required = false, defaultValue = "20") Integer limit,
             @RequestParam(required = false) Long cursor
     ) {
-        return getActivityListUseCase.getActivityList(memberId, category, scope, cursor);
+        return getActivityListUseCase.getActivityList(memberId, category, scope, limit, cursor);
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "활동 검색", description = "활동 제목을 기준으로 검색합니다. (부분 일치)")
+    public ActivityListResponse searchActivities(
+        @AuthenticationPrincipal Long memberId,
+        @RequestParam String keyword,
+        @RequestParam(required = false, defaultValue = "20") Integer limit,
+        @RequestParam(required = false) Long cursor
+    ) {
+        return searchActivityUseCase.searchActivities(memberId, keyword, limit, cursor);
     }
 
     @GetMapping("/{activityId}/details")

--- a/src/main/java/com/awp/mgw/activity/controller/ActivityController.java
+++ b/src/main/java/com/awp/mgw/activity/controller/ActivityController.java
@@ -18,6 +18,7 @@ import com.awp.mgw.activity.usecase.SearchActivityUseCase;
 import com.awp.mgw.activity.usecase.UnlikeActivityUseCase;
 import com.awp.mgw.activity.usecase.UploadActivityImageUseCase;
 import com.awp.mgw.activity.usecase.UpdateActivityUseCase;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -57,6 +58,7 @@ public class ActivityController {
     @PostMapping
     @Operation(summary = "활동 생성", description = "신규 활동을 생성합니다.")
     public ActivityIdResponse createActivity(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal Long memberId,
         @Valid @RequestBody CreateActivityRequest request
     ) {
@@ -66,6 +68,7 @@ public class ActivityController {
     @PutMapping("/{activityId}")
     @Operation(summary = "활동 수정", description = "기존 활동을 수정합니다.")
     public ActivityIdResponse updateActivity(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal Long memberId,
         @PathVariable Long activityId,
         @Valid @RequestBody UpdateActivityRequest request
@@ -76,6 +79,7 @@ public class ActivityController {
     @DeleteMapping("/{activityId}")
     @Operation(summary = "활동 삭제", description = "기존 활동을 삭제합니다.")
     public ActivityIdResponse deleteActivity(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal Long memberId,
         @PathVariable Long activityId
     ) {
@@ -85,6 +89,7 @@ public class ActivityController {
     @GetMapping
     @Operation(summary = "활동 통합 조회", description = "scope, category, cursor 조건으로 활동 목록을 조회합니다.")
     public ActivityListResponse getActivities(
+            @Parameter(hidden = true)
             @AuthenticationPrincipal Long memberId,
             @RequestParam(required = false) String category,
             @RequestParam(required = false) String scope,
@@ -97,6 +102,7 @@ public class ActivityController {
     @GetMapping("/search")
     @Operation(summary = "활동 검색", description = "활동 제목을 기준으로 검색합니다. (부분 일치)")
     public ActivityListResponse searchActivities(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal Long memberId,
         @RequestParam String keyword,
         @RequestParam(required = false, defaultValue = "20") Integer limit,
@@ -108,6 +114,7 @@ public class ActivityController {
     @GetMapping("/{activityId}/details")
     @Operation(summary = "활동 상세 조회", description = "활동 상세 정보를 조회합니다.")
     public ActivityDetailResponse getActivityDetail(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal Long memberId,
         @PathVariable Long activityId
     ) {
@@ -117,6 +124,7 @@ public class ActivityController {
     @PostMapping("/{activityId}/members")
     @Operation(summary = "활동 참여", description = "개인 또는 그룹으로 활동에 참여합니다.")
     public ActivityIdResponse joinActivity(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal Long memberId,
         @PathVariable Long activityId,
         @Valid @RequestBody JoinActivityRequest request
@@ -127,6 +135,7 @@ public class ActivityController {
     @DeleteMapping("/{activityId}/members")
     @Operation(summary = "활동 탈퇴", description = "참여 중인 활동에서 탈퇴합니다.")
     public ActivityIdResponse leaveActivity(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal Long memberId,
         @PathVariable Long activityId
     ) {
@@ -136,6 +145,7 @@ public class ActivityController {
     @PostMapping("/{activityId}/likes")
     @Operation(summary = "활동 좋아요", description = "활동 좋아요를 추가합니다.")
     public ActivityIdResponse likeActivity(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal Long memberId,
         @PathVariable Long activityId
     ) {
@@ -145,6 +155,7 @@ public class ActivityController {
     @DeleteMapping("/{activityId}/likes")
     @Operation(summary = "활동 좋아요 취소", description = "활동 좋아요를 취소합니다.")
     public ActivityIdResponse unlikeActivity(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal Long memberId,
         @PathVariable Long activityId
     ) {
@@ -154,6 +165,7 @@ public class ActivityController {
     @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "활동 이미지 업로드", description = "활동 이미지를 업로드하고 저장 경로를 반환합니다.")
     public ActivityImageUploadResponse uploadActivityImage(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal Long memberId,
         @RequestPart("file") MultipartFile file
     ) {

--- a/src/main/java/com/awp/mgw/activity/port/ActivityQueryRepository.java
+++ b/src/main/java/com/awp/mgw/activity/port/ActivityQueryRepository.java
@@ -66,6 +66,31 @@ public class ActivityQueryRepository {
             .fetch();
     }
 
+    public List<ActivitySummaryRow> searchActivitySummaries(Long memberId, String keyword, Long cursor, int size) {
+        return queryFactory
+            .select(Projections.constructor(
+                ActivitySummaryRow.class,
+                activity.id,
+                activity.title,
+                categoryNameExpression(),
+                activity.maxMember,
+                currentParticipantCountExpression(activity.id),
+                isLikedExpression(memberId, activity.id),
+                likeCountExpression(activity.id),
+                activity.schedule,
+                activity.thumbnailUrl,
+                scoreExpression(activity.id)
+            ))
+            .from(activity)
+            .where(
+                cursorLt(cursor),
+                titleContains(keyword)
+            )
+            .orderBy(activity.id.desc())
+            .limit(size)
+            .fetch();
+    }
+
     public ActivitySummaryRow findTopHotpick(Long memberId, String categoryName) {
         return queryFactory
             .select(Projections.constructor(
@@ -306,6 +331,13 @@ public class ActivityQueryRepository {
         }
 
         return null;
+    }
+
+    private BooleanExpression titleContains(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+        return activity.title.containsIgnoreCase(keyword);
     }
 
     private Expression<String> categoryNameExpression() {

--- a/src/main/java/com/awp/mgw/activity/service/ActivityQueryService.java
+++ b/src/main/java/com/awp/mgw/activity/service/ActivityQueryService.java
@@ -10,6 +10,7 @@ import com.awp.mgw.activity.port.ActivityQueryRepository;
 import com.awp.mgw.activity.port.ActivityRepository;
 import com.awp.mgw.activity.usecase.GetActivityDetailUseCase;
 import com.awp.mgw.activity.usecase.GetActivityListUseCase;
+import com.awp.mgw.activity.usecase.SearchActivityUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,16 +20,17 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class ActivityQueryService implements GetActivityListUseCase, GetActivityDetailUseCase {
+public class ActivityQueryService implements GetActivityListUseCase, GetActivityDetailUseCase, SearchActivityUseCase {
 
-    private static final int PAGE_SIZE = 20;
+    private static final int DEFAULT_PAGE_SIZE = 20;
 
     private final ActivityRepository activityRepository;
     private final ActivityQueryRepository activityQueryRepository;
 
     @Override
-    public ActivityListResponse getActivityList(Long memberId, String category, String scope, Long cursor) {
+    public ActivityListResponse getActivityList(Long memberId, String category, String scope, Integer limit, Long cursor) {
         validateScopeMemberId(scope, memberId);
+        int pageSize = normalizeLimit(limit);
 
         ActivityQueryRepository.ActivitySummaryRow hotpickRow = activityQueryRepository.findTopHotpick(memberId, null);
         Long hotpickId = hotpickRow == null ? null : hotpickRow.id();
@@ -40,10 +42,10 @@ public class ActivityQueryService implements GetActivityListUseCase, GetActivity
         }
 
         List<ActivityQueryRepository.ActivitySummaryRow> rows =
-            activityQueryRepository.findActivitySummaries(memberId, category, scope, cursor, PAGE_SIZE + 1);
+            activityQueryRepository.findActivitySummaries(memberId, category, scope, cursor, pageSize + 1);
 
-        boolean hasNext = rows.size() > PAGE_SIZE;
-        List<ActivityQueryRepository.ActivitySummaryRow> pagedRows = hasNext ? rows.subList(0, PAGE_SIZE) : rows;
+        boolean hasNext = rows.size() > pageSize;
+        List<ActivityQueryRepository.ActivitySummaryRow> pagedRows = hasNext ? rows.subList(0, pageSize) : rows;
 
         List<ActivitySummaryResponse> activities = pagedRows.stream()
             .map(row -> mapSummary(row, hotpickId))
@@ -52,6 +54,28 @@ public class ActivityQueryService implements GetActivityListUseCase, GetActivity
         String nextCursor = hasNext ? String.valueOf(pagedRows.get(pagedRows.size() - 1).id()) : null;
         ActivitySummaryResponse responseHotpick = (scope == null || scope.isBlank()) ? hotpick : null;
         return new ActivityListResponse(responseHotpick, activities, nextCursor);
+    }
+
+    @Override
+    public ActivityListResponse searchActivities(Long memberId, String keyword, Integer limit, Long cursor) {
+        validateKeyword(keyword);
+        int pageSize = normalizeLimit(limit);
+
+        List<ActivityQueryRepository.ActivitySummaryRow> rows =
+            activityQueryRepository.searchActivitySummaries(memberId, keyword, cursor, pageSize + 1);
+
+        boolean hasNext = rows.size() > pageSize;
+        List<ActivityQueryRepository.ActivitySummaryRow> pagedRows = hasNext ? rows.subList(0, pageSize) : rows;
+
+        ActivityQueryRepository.ActivitySummaryRow hotpickRow = activityQueryRepository.findTopHotpick(memberId, null);
+        Long hotpickId = hotpickRow == null ? null : hotpickRow.id();
+
+        List<ActivitySummaryResponse> activities = pagedRows.stream()
+            .map(row -> mapSummary(row, hotpickId))
+            .toList();
+
+        String nextCursor = hasNext ? String.valueOf(pagedRows.get(pagedRows.size() - 1).id()) : null;
+        return new ActivityListResponse(null, activities, nextCursor);
     }
 
     @Override
@@ -101,6 +125,19 @@ public class ActivityQueryService implements GetActivityListUseCase, GetActivity
 
         if (("joined".equalsIgnoreCase(scope) || "created".equalsIgnoreCase(scope)) && memberId == null) {
             throw new ActivityDomainException(ActivityErrorCode.MEMBER_ID_REQUIRED_FOR_SCOPE);
+        }
+    }
+
+    private int normalizeLimit(Integer limit) {
+        if (limit == null || limit < 1) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return limit;
+    }
+
+    private void validateKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            throw new ActivityDomainException(ActivityErrorCode.INVALID_ACTIVITY_TITLE);
         }
     }
 

--- a/src/main/java/com/awp/mgw/activity/usecase/GetActivityListUseCase.java
+++ b/src/main/java/com/awp/mgw/activity/usecase/GetActivityListUseCase.java
@@ -3,5 +3,5 @@ package com.awp.mgw.activity.usecase;
 import com.awp.mgw.activity.controller.dto.response.ActivityListResponse;
 
 public interface GetActivityListUseCase {
-    ActivityListResponse getActivityList(Long memberId, String category, String scope, Long cursor);
+    ActivityListResponse getActivityList(Long memberId, String category, String scope, Integer limit, Long cursor);
 }

--- a/src/main/java/com/awp/mgw/activity/usecase/SearchActivityUseCase.java
+++ b/src/main/java/com/awp/mgw/activity/usecase/SearchActivityUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.activity.usecase;
+
+import com.awp.mgw.activity.controller.dto.response.ActivityListResponse;
+
+public interface SearchActivityUseCase {
+    ActivityListResponse searchActivities(Long memberId, String keyword, Integer limit, Long cursor);
+}

--- a/src/main/java/com/awp/mgw/global/config/OpenApiConfig.java
+++ b/src/main/java/com/awp/mgw/global/config/OpenApiConfig.java
@@ -1,0 +1,24 @@
+package com.awp.mgw.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    security = {
+        @SecurityRequirement(name = "bearerAuth")
+    }
+)
+@SecurityScheme(
+    name = "bearerAuth",
+    type = SecuritySchemeType.HTTP,
+    scheme = "bearer",
+    bearerFormat = "JWT",
+    in = SecuritySchemeIn.HEADER
+)
+public class OpenApiConfig {
+}

--- a/src/main/java/com/awp/mgw/global/config/SecurityConfig.java
+++ b/src/main/java/com/awp/mgw/global/config/SecurityConfig.java
@@ -46,7 +46,10 @@ public class SecurityConfig {
                       "/api/v1/auth/token/reissue",
                       "/api/v1/auth/email-verification/send",
                       "/api/v1/auth/email-verification/resend",
-                      "/api/v1/auth/email-verification/verify"
+                      "/api/v1/auth/email-verification/verify",
+                      "/swagger-ui.html",
+                      "/swagger-ui/**",
+                      "/v3/api-docs/**"
                 ).permitAll()
                 .anyRequest().authenticated()
           )

--- a/src/test/java/com/awp/mgw/activity/service/ActivityQueryServiceTest.java
+++ b/src/test/java/com/awp/mgw/activity/service/ActivityQueryServiceTest.java
@@ -1,0 +1,87 @@
+package com.awp.mgw.activity.service;
+
+import com.awp.mgw.activity.controller.dto.response.ActivityListResponse;
+import com.awp.mgw.activity.domain.exception.ActivityDomainException;
+import com.awp.mgw.activity.port.ActivityQueryRepository;
+import com.awp.mgw.activity.port.ActivityRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ActivityQueryServiceTest {
+
+    @Mock
+    private ActivityRepository activityRepository;
+
+    @Mock
+    private ActivityQueryRepository activityQueryRepository;
+
+    @InjectMocks
+    private ActivityQueryService activityQueryService;
+
+    @Test
+    void getActivityListUsesRequestedLimitForPaging() {
+        when(activityQueryRepository.findTopHotpick(1L, null)).thenReturn(null);
+        when(activityQueryRepository.findActivitySummaries(1L, null, null, 30L, 6))
+            .thenReturn(List.of(
+                row(29L, "a"),
+                row(28L, "b"),
+                row(27L, "c")
+            ));
+
+        ActivityListResponse response = activityQueryService.getActivityList(1L, null, null, 5, 30L);
+
+        verify(activityQueryRepository).findActivitySummaries(1L, null, null, 30L, 6);
+        assertThat(response.activities()).hasSize(3);
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    void searchActivitiesReturnsNextCursorUsingLimit() {
+        when(activityQueryRepository.searchActivitySummaries(1L, "러닝", 100L, 3))
+            .thenReturn(List.of(
+                row(99L, "러닝 1"),
+                row(98L, "러닝 2"),
+                row(97L, "러닝 3")
+            ));
+        when(activityQueryRepository.findTopHotpick(1L, null)).thenReturn(null);
+
+        ActivityListResponse response = activityQueryService.searchActivities(1L, "러닝", 2, 100L);
+
+        verify(activityQueryRepository).searchActivitySummaries(1L, "러닝", 100L, 3);
+        assertThat(response.activities()).hasSize(2);
+        assertThat(response.nextCursor()).isEqualTo("98");
+    }
+
+    @Test
+    void searchActivitiesThrowsWhenKeywordBlank() {
+        assertThatThrownBy(() -> activityQueryService.searchActivities(1L, " ", 20, null))
+            .isInstanceOf(ActivityDomainException.class);
+    }
+
+    private ActivityQueryRepository.ActivitySummaryRow row(Long id, String title) {
+        return new ActivityQueryRepository.ActivitySummaryRow(
+            id,
+            title,
+            "운동",
+            10,
+            1L,
+            false,
+            0L,
+            Instant.parse("2026-05-10T00:00:00Z"),
+            "thumbnail",
+            1L
+        );
+    }
+}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 모든 활동 API에 대해서 인증객체로 유저 아이디 접근으로 변경
- [x] 키워드 검색 API 구현
- [x] limit 커리스트링 추가

## 🔥 연관 이슈

> `closes`, `resolves`, `fixes`, `related to`와 같은 키워드를 적절히 사용해서 Issue와 PR을 연결해주세요.

- resolves #

## 🚀 작업 내용

<img width="1400" height="870" alt="image" src="https://github.com/user-attachments/assets/5f9ae727-59ee-4a5e-a2d7-2b4d4e08fdb2" />

- 키워드 검색 API
---

<img width="1404" height="793" alt="image" src="https://github.com/user-attachments/assets/a4be9b7a-dce0-4377-b383-890e96f4632a" />

- limit 쿼리스트링 추가
----

<img width="1520" height="438" alt="image" src="https://github.com/user-attachments/assets/0304b3f1-1993-4db4-9c26-f7e17b920579" />

- swagger에 jwt토큰 로그인 추가
----

## 💬 리뷰 중점사항

> 작업 내용 중에서 **리뷰어가 중점적으로 봐야 하는 사항**들을 명시해주세요.
>
> _e.g._ `NullPointerException` 발생을 대비해서 추가한 로직에 대한 검수를 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 액티비티 검색 기능 추가 (키워드 기반 검색 지원)
  * 액티비티 목록 조회 시 페이지 크기 제한 설정 가능 (기본값 20)

* **문서**
  * OpenAPI(Swagger) 문서화 추가 및 API 엔드포인트 조회 가능

* **보안**
  * API 문서에 대한 인증 설정 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GCU-makeGroup/MGW-server/pull/41)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->