### PR TITLE
feat : 백엔드 API 연동 보완 — 검색 확장, MyPage 설정, 댓글/인증 API

### DIFF
--- a/src/main/java/com/awp/mgw/activity/port/ActivityQueryRepository.java
+++ b/src/main/java/com/awp/mgw/activity/port/ActivityQueryRepository.java
@@ -337,7 +337,8 @@ public class ActivityQueryRepository {
         if (keyword == null || keyword.isBlank()) {
             return null;
         }
-        return activity.title.containsIgnoreCase(keyword);
+        return activity.title.containsIgnoreCase(keyword)
+                .or(activity.description.containsIgnoreCase(keyword));
     }
 
     private Expression<String> categoryNameExpression() {

--- a/src/main/java/com/awp/mgw/group/controller/GroupController.java
+++ b/src/main/java/com/awp/mgw/group/controller/GroupController.java
@@ -2,15 +2,18 @@ package com.awp.mgw.group.controller;
 
 import com.awp.mgw.group.controller.dto.request.CreateCommentRequest;
 import com.awp.mgw.group.controller.dto.request.CreateGroupRequest;
+import com.awp.mgw.group.controller.dto.request.UpdateCommentRequest;
 import com.awp.mgw.group.controller.dto.response.CreateCommentResponse;
 import com.awp.mgw.group.controller.dto.response.CreateGroupResponse;
 import com.awp.mgw.group.controller.dto.response.GetGroupDetailResponse;
 import com.awp.mgw.group.controller.dto.response.GetGroupListResponse;
 import com.awp.mgw.group.usecase.command.CreateCommentUseCase;
 import com.awp.mgw.group.usecase.command.CreateGroupUseCase;
+import com.awp.mgw.group.usecase.command.DeleteCommentUseCase;
 import com.awp.mgw.group.usecase.command.DeleteGroupUseCase;
 import com.awp.mgw.group.usecase.command.LeaveGroupUseCase;
 import com.awp.mgw.group.usecase.command.JoinGroupUseCase;
+import com.awp.mgw.group.usecase.command.UpdateCommentUseCase;
 import com.awp.mgw.group.usecase.command.UpdateGroupUseCase;
 import com.awp.mgw.group.usecase.query.GetGroupDetailUseCase;
 import com.awp.mgw.group.usecase.query.GetGroupListUseCase;
@@ -45,6 +48,8 @@ public class GroupController {
     private final JoinGroupUseCase joinGroupUseCase;
     private final DeleteGroupUseCase deleteGroupUseCase;
     private final LeaveGroupUseCase leaveGroupUseCase;
+    private final DeleteCommentUseCase deleteCommentUseCase;
+    private final UpdateCommentUseCase updateCommentUseCase;
     private final GetGroupListUseCase getGroupListUseCase;
     private final GetMyGroupListUseCase getMyGroupListUseCase;
     private final SearchGroupListUseCase searchGroupListUseCase;
@@ -161,6 +166,37 @@ public class GroupController {
             @Valid @RequestBody CreateCommentRequest request
     ) {
         return createCommentUseCase.createComment(memberId, groupId, request);
+    }
+
+    @PutMapping("/{groupId}/comments/{commentId}")
+    @Operation(
+            summary = "댓글 수정",
+            description = "댓글 작성자만 수정할 수 있습니다."
+    )
+    public void updateComment(
+            @AuthenticationPrincipal Long memberId,
+            @Parameter(description = "그룹 ID", example = "10")
+            @PathVariable Long groupId,
+            @Parameter(description = "수정할 댓글 ID", example = "5")
+            @PathVariable Long commentId,
+            @Valid @RequestBody UpdateCommentRequest request
+    ) {
+        updateCommentUseCase.updateComment(memberId, groupId, commentId, request);
+    }
+
+    @DeleteMapping("/{groupId}/comments/{commentId}")
+    @Operation(
+            summary = "댓글 삭제",
+            description = "댓글 작성자만 삭제할 수 있습니다."
+    )
+    public void deleteComment(
+            @AuthenticationPrincipal Long memberId,
+            @Parameter(description = "그룹 ID", example = "10")
+            @PathVariable Long groupId,
+            @Parameter(description = "삭제할 댓글 ID", example = "5")
+            @PathVariable Long commentId
+    ) {
+        deleteCommentUseCase.deleteComment(memberId, groupId, commentId);
     }
 
     @DeleteMapping("/{groupId}")

--- a/src/main/java/com/awp/mgw/group/controller/dto/request/UpdateCommentRequest.java
+++ b/src/main/java/com/awp/mgw/group/controller/dto/request/UpdateCommentRequest.java
@@ -1,0 +1,11 @@
+package com.awp.mgw.group.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateCommentRequest(
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        @Size(max = 1000, message = "댓글 내용은 1000자 이하여야 합니다.")
+        String content
+) {
+}

--- a/src/main/java/com/awp/mgw/group/domain/Comment.java
+++ b/src/main/java/com/awp/mgw/group/domain/Comment.java
@@ -1,6 +1,8 @@
 package com.awp.mgw.group.domain;
 
 import com.awp.mgw.common.BaseEntity;
+import com.awp.mgw.group.domain.exception.GroupDomainException;
+import com.awp.mgw.group.domain.exception.GroupErrorCode;
 import com.awp.mgw.member.domain.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -70,5 +72,12 @@ public class Comment extends BaseEntity {
 
     public void detachMember() {
         this.member = null;
+    }
+
+    public void updateContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw new GroupDomainException(GroupErrorCode.INVALID_COMMENT_CONTENT);
+        }
+        this.content = content;
     }
 }

--- a/src/main/java/com/awp/mgw/group/port/GroupQueryRepository.java
+++ b/src/main/java/com/awp/mgw/group/port/GroupQueryRepository.java
@@ -239,8 +239,11 @@ public class GroupQueryRepository {
             return null;
         }
 
-        return Expressions.stringTemplate("replace({0}, ' ', '')", group.name)
+        BooleanExpression nameMatch = Expressions.stringTemplate("replace({0}, ' ', '')", group.name)
                 .containsIgnoreCase(normalizedKeyword);
+        BooleanExpression titleMatch = Expressions.stringTemplate("replace({0}, ' ', '')", group.title)
+                .containsIgnoreCase(normalizedKeyword);
+        return nameMatch.or(titleMatch);
     }
 
     private BooleanExpression accessibleGroup(Long memberId) {

--- a/src/main/java/com/awp/mgw/group/service/GroupCommandService.java
+++ b/src/main/java/com/awp/mgw/group/service/GroupCommandService.java
@@ -7,6 +7,7 @@ import com.awp.mgw.category.domain.exception.CategoryErrorCode;
 import com.awp.mgw.category.port.CategoryRepository;
 import com.awp.mgw.group.controller.dto.request.CreateCommentRequest;
 import com.awp.mgw.group.controller.dto.request.CreateGroupRequest;
+import com.awp.mgw.group.controller.dto.request.UpdateCommentRequest;
 import com.awp.mgw.group.controller.dto.response.CreateCommentResponse;
 import com.awp.mgw.group.controller.dto.response.CreateGroupResponse;
 import com.awp.mgw.group.domain.Comment;
@@ -21,9 +22,11 @@ import com.awp.mgw.group.port.GroupMemberRepository;
 import com.awp.mgw.group.port.GroupRepository;
 import com.awp.mgw.group.usecase.command.CreateCommentUseCase;
 import com.awp.mgw.group.usecase.command.CreateGroupUseCase;
+import com.awp.mgw.group.usecase.command.DeleteCommentUseCase;
 import com.awp.mgw.group.usecase.command.DeleteGroupUseCase;
 import com.awp.mgw.group.usecase.command.LeaveGroupUseCase;
 import com.awp.mgw.group.usecase.command.JoinGroupUseCase;
+import com.awp.mgw.group.usecase.command.UpdateCommentUseCase;
 import com.awp.mgw.group.usecase.command.UpdateGroupUseCase;
 import com.awp.mgw.member.domain.Member;
 import com.awp.mgw.member.domain.exception.MemberDomainException;
@@ -38,7 +41,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class GroupCommandService implements CreateGroupUseCase, CreateCommentUseCase, UpdateGroupUseCase, JoinGroupUseCase, DeleteGroupUseCase, LeaveGroupUseCase {
+public class GroupCommandService implements CreateGroupUseCase, CreateCommentUseCase, UpdateGroupUseCase, JoinGroupUseCase, DeleteGroupUseCase, LeaveGroupUseCase, DeleteCommentUseCase, UpdateCommentUseCase {
 
     private final GroupRepository groupRepository;
     private final CommentRepository commentRepository;
@@ -161,6 +164,22 @@ public class GroupCommandService implements CreateGroupUseCase, CreateCommentUse
         return CreateCommentResponse.from(savedComment.getId(), authorGroupMember);
     }
 
+    @Override
+    public void deleteComment(Long memberId, Long groupId, Long commentId) {
+        getMemberOrThrow(memberId);
+        getGroupOrThrow(groupId);
+        Comment comment = getOwnedCommentOrThrow(commentId, memberId, groupId);
+        commentRepository.delete(comment);
+    }
+
+    @Override
+    public void updateComment(Long memberId, Long groupId, Long commentId, UpdateCommentRequest request) {
+        getMemberOrThrow(memberId);
+        getGroupOrThrow(groupId);
+        Comment comment = getOwnedCommentOrThrow(commentId, memberId, groupId);
+        comment.updateContent(request.content());
+    }
+
     /**
      * 그룹 정원 유효성 검증
      */
@@ -218,6 +237,21 @@ public class GroupCommandService implements CreateGroupUseCase, CreateCommentUse
         }
 
         return parent;
+    }
+
+    private Comment getOwnedCommentOrThrow(Long commentId, Long memberId, Long groupId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new GroupDomainException(GroupErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getGroup().getId().equals(groupId)) {
+            throw new GroupDomainException(GroupErrorCode.INVALID_COMMENT_PARENT);
+        }
+
+        if (comment.getMember() == null || !comment.getMember().getId().equals(memberId)) {
+            throw new GroupDomainException(GroupErrorCode.COMMENT_NOT_OWNED);
+        }
+
+        return comment;
     }
 
     private List<Category> getCategoriesOrThrow(List<Long> categoryIds) {

--- a/src/main/java/com/awp/mgw/group/usecase/command/DeleteCommentUseCase.java
+++ b/src/main/java/com/awp/mgw/group/usecase/command/DeleteCommentUseCase.java
@@ -1,0 +1,5 @@
+package com.awp.mgw.group.usecase.command;
+
+public interface DeleteCommentUseCase {
+    void deleteComment(Long memberId, Long groupId, Long commentId);
+}

--- a/src/main/java/com/awp/mgw/group/usecase/command/UpdateCommentUseCase.java
+++ b/src/main/java/com/awp/mgw/group/usecase/command/UpdateCommentUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.group.usecase.command;
+
+import com.awp.mgw.group.controller.dto.request.UpdateCommentRequest;
+
+public interface UpdateCommentUseCase {
+    void updateComment(Long memberId, Long groupId, Long commentId, UpdateCommentRequest request);
+}

--- a/src/main/java/com/awp/mgw/member/controller/AuthController.java
+++ b/src/main/java/com/awp/mgw/member/controller/AuthController.java
@@ -1,11 +1,14 @@
 package com.awp.mgw.member.controller;
 
+import com.awp.mgw.member.controller.dto.request.ChangePasswordRequest;
 import com.awp.mgw.member.controller.dto.request.LoginRequest;
 import com.awp.mgw.member.controller.dto.request.SignupRequest;
 import com.awp.mgw.member.controller.dto.response.LoginResponse;
 import com.awp.mgw.member.controller.dto.response.SignupResponse;
+import com.awp.mgw.member.usecase.ChangePasswordUseCase;
 import com.awp.mgw.member.usecase.LoginUseCase;
 import com.awp.mgw.member.usecase.SignupUseCase;
+import com.awp.mgw.member.usecase.WithdrawMemberUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -30,6 +33,8 @@ public class AuthController {
   private final VerifyEmailVerificationUseCase verifyEmailVerificationUseCase;
   private final ReissueTokenUseCase reissueTokenUseCase;
   private final LogoutUseCase logoutUseCase;
+  private final ChangePasswordUseCase changePasswordUseCase;
+  private final WithdrawMemberUseCase withdrawMemberUseCase;
 
   @PostMapping("/signup")
   public SignupResponse signup(@Valid @RequestBody SignupRequest request) {
@@ -72,5 +77,18 @@ public class AuthController {
         @Valid @RequestBody TokenReissueRequest request
   ) {
     return reissueTokenUseCase.reissue(request.refreshToken());
+  }
+
+  @PatchMapping("/password")
+  public void changePassword(
+        @AuthenticationPrincipal Long memberId,
+        @Valid @RequestBody ChangePasswordRequest request
+  ) {
+    changePasswordUseCase.changePassword(memberId, request);
+  }
+
+  @DeleteMapping("/withdraw")
+  public void withdraw(@AuthenticationPrincipal Long memberId) {
+    withdrawMemberUseCase.withdraw(memberId);
   }
 }

--- a/src/main/java/com/awp/mgw/member/controller/AuthController.java
+++ b/src/main/java/com/awp/mgw/member/controller/AuthController.java
@@ -2,11 +2,13 @@ package com.awp.mgw.member.controller;
 
 import com.awp.mgw.member.controller.dto.request.ChangePasswordRequest;
 import com.awp.mgw.member.controller.dto.request.LoginRequest;
+import com.awp.mgw.member.controller.dto.request.SavePreferencesRequest;
 import com.awp.mgw.member.controller.dto.request.SignupRequest;
 import com.awp.mgw.member.controller.dto.response.LoginResponse;
 import com.awp.mgw.member.controller.dto.response.SignupResponse;
 import com.awp.mgw.member.usecase.ChangePasswordUseCase;
 import com.awp.mgw.member.usecase.LoginUseCase;
+import com.awp.mgw.member.usecase.SavePreferencesUseCase;
 import com.awp.mgw.member.usecase.SignupUseCase;
 import com.awp.mgw.member.usecase.WithdrawMemberUseCase;
 import jakarta.validation.Valid;
@@ -35,6 +37,7 @@ public class AuthController {
   private final LogoutUseCase logoutUseCase;
   private final ChangePasswordUseCase changePasswordUseCase;
   private final WithdrawMemberUseCase withdrawMemberUseCase;
+  private final SavePreferencesUseCase savePreferencesUseCase;
 
   @PostMapping("/signup")
   public SignupResponse signup(@Valid @RequestBody SignupRequest request) {
@@ -90,5 +93,13 @@ public class AuthController {
   @DeleteMapping("/withdraw")
   public void withdraw(@AuthenticationPrincipal Long memberId) {
     withdrawMemberUseCase.withdraw(memberId);
+  }
+
+  @PostMapping("/preferences")
+  public void savePreferences(
+        @AuthenticationPrincipal Long memberId,
+        @RequestBody SavePreferencesRequest request
+  ) {
+    savePreferencesUseCase.savePreferences(memberId, request);
   }
 }

--- a/src/main/java/com/awp/mgw/member/controller/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/com/awp/mgw/member/controller/dto/request/ChangePasswordRequest.java
@@ -1,0 +1,14 @@
+package com.awp.mgw.member.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChangePasswordRequest(
+        @NotBlank(message = "현재 비밀번호는 필수입니다.")
+        String currentPassword,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        @Size(min = 8, max = 50, message = "비밀번호는 8자 이상 50자 이하여야 합니다.")
+        String newPassword
+) {
+}

--- a/src/main/java/com/awp/mgw/member/controller/dto/request/SavePreferencesRequest.java
+++ b/src/main/java/com/awp/mgw/member/controller/dto/request/SavePreferencesRequest.java
@@ -1,0 +1,9 @@
+package com.awp.mgw.member.controller.dto.request;
+
+import java.util.List;
+
+public record SavePreferencesRequest(
+        List<String> interestKeywords,
+        String purpose
+) {
+}

--- a/src/main/java/com/awp/mgw/member/domain/Member.java
+++ b/src/main/java/com/awp/mgw/member/domain/Member.java
@@ -106,4 +106,21 @@ public class Member extends BaseEntity {
         groups.forEach(Group::detachMember);
         comments.forEach(Comment::detachMember);
     }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
+    public void softDelete() {
+        this.deletedAt = Instant.now();
+    }
+
+    public void updateProfile(String name, String imageUrl) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        if (imageUrl != null) {
+            this.imageUrl = imageUrl;
+        }
+    }
 }

--- a/src/main/java/com/awp/mgw/member/domain/MemberSetting.java
+++ b/src/main/java/com/awp/mgw/member/domain/MemberSetting.java
@@ -66,4 +66,18 @@ public class MemberSetting extends BaseEntity {
             .postCommentNotification(true)
             .build();
     }
+
+    public void updateLanguage(Language language) {
+        this.language = language;
+    }
+
+    public void updateDarkMode(Boolean darkMode) {
+        this.darkMode = darkMode;
+    }
+
+    public void updateNotifications(Boolean messageNotification, Boolean groupInviteNotification, Boolean postCommentNotification) {
+        if (messageNotification != null) this.messageNotification = messageNotification;
+        if (groupInviteNotification != null) this.groupInviteNotification = groupInviteNotification;
+        if (postCommentNotification != null) this.postCommentNotification = postCommentNotification;
+    }
 }

--- a/src/main/java/com/awp/mgw/member/domain/MemberSetting.java
+++ b/src/main/java/com/awp/mgw/member/domain/MemberSetting.java
@@ -3,6 +3,7 @@ package com.awp.mgw.member.domain;
 import com.awp.mgw.common.BaseEntity;
 import com.awp.mgw.member.domain.enums.Language;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -13,6 +14,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.*;
 
 @Entity
@@ -45,15 +48,25 @@ public class MemberSetting extends BaseEntity {
     @Column(name = "post_comment_notification", nullable = false)
     private Boolean postCommentNotification = true;
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Column(name = "interest_keyword")
+    private List<String> interestKeywords = new ArrayList<>();
+
+    @Column(name = "purpose", columnDefinition = "TEXT")
+    private String purpose;
+
     @Builder(access = AccessLevel.PRIVATE)
     private MemberSetting(Member member, Language language, Boolean darkMode, Boolean messageNotification,
-                          Boolean groupInviteNotification, Boolean postCommentNotification) {
+                          Boolean groupInviteNotification, Boolean postCommentNotification,
+                          List<String> interestKeywords, String purpose) {
         this.member = member;
         this.language = language;
         this.darkMode = darkMode;
         this.messageNotification = messageNotification;
         this.groupInviteNotification = groupInviteNotification;
         this.postCommentNotification = postCommentNotification;
+        this.interestKeywords = interestKeywords != null ? interestKeywords : new ArrayList<>();
+        this.purpose = purpose;
     }
 
     public static MemberSetting create(Member member, Language language) {
@@ -79,5 +92,13 @@ public class MemberSetting extends BaseEntity {
         if (messageNotification != null) this.messageNotification = messageNotification;
         if (groupInviteNotification != null) this.groupInviteNotification = groupInviteNotification;
         if (postCommentNotification != null) this.postCommentNotification = postCommentNotification;
+    }
+
+    public void updateInterestKeywords(List<String> keywords) {
+        this.interestKeywords = keywords != null ? keywords : new ArrayList<>();
+    }
+
+    public void updatePurpose(String purpose) {
+        this.purpose = purpose;
     }
 }

--- a/src/main/java/com/awp/mgw/member/domain/exception/MemberErrorCode.java
+++ b/src/main/java/com/awp/mgw/member/domain/exception/MemberErrorCode.java
@@ -30,7 +30,10 @@ public enum MemberErrorCode implements BaseCode {
 
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "MEMBER-015", "Refresh Token이 유효하지 않습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "MEMBER-016", "Refresh Token이 만료되었습니다."),
-    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "MEMBER-017", "이메일 인증이 완료되지 않았습니다.");
+    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "MEMBER-017", "이메일 인증이 완료되지 않았습니다."),
+
+    INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER-018", "현재 비밀번호가 일치하지 않습니다."),
+    MEMBER_WITHDRAWN(HttpStatus.FORBIDDEN, "MEMBER-019", "탈퇴한 회원입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/awp/mgw/member/port/MemberSettingRepository.java
+++ b/src/main/java/com/awp/mgw/member/port/MemberSettingRepository.java
@@ -1,0 +1,10 @@
+package com.awp.mgw.member.port;
+
+import com.awp.mgw.member.domain.MemberSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberSettingRepository extends JpaRepository<MemberSetting, Long> {
+    Optional<MemberSetting> findByMember_Id(Long memberId);
+}

--- a/src/main/java/com/awp/mgw/member/service/AuthCommandService.java
+++ b/src/main/java/com/awp/mgw/member/service/AuthCommandService.java
@@ -89,6 +89,10 @@ public class AuthCommandService implements SignupUseCase, LoginUseCase, LogoutUs
       throw new MemberDomainException(MemberErrorCode.INVALID_LOGIN_INFO);
     }
 
+    if (member.getDeletedAt() != null) {
+      throw new MemberDomainException(MemberErrorCode.MEMBER_WITHDRAWN);
+    }
+
     String accessToken = jwtTokenProvider.createAccessToken(
           member.getId(),
           member.getEmail()
@@ -173,6 +177,13 @@ public class AuthCommandService implements SignupUseCase, LoginUseCase, LogoutUs
     }
 
     Long memberId = jwtTokenProvider.getMemberId(refreshToken);
+
+    Member member = memberRepository.findById(memberId)
+          .orElseThrow(() -> new MemberDomainException(MemberErrorCode.INVALID_REFRESH_TOKEN));
+
+    if (member.getDeletedAt() != null) {
+      throw new MemberDomainException(MemberErrorCode.MEMBER_WITHDRAWN);
+    }
 
     RefreshToken savedToken = refreshTokenRepository.findByMemberId(memberId)
           .orElseThrow(() -> new MemberDomainException(MemberErrorCode.INVALID_REFRESH_TOKEN));

--- a/src/main/java/com/awp/mgw/member/service/MemberCommandService.java
+++ b/src/main/java/com/awp/mgw/member/service/MemberCommandService.java
@@ -1,12 +1,16 @@
 package com.awp.mgw.member.service;
 
 import com.awp.mgw.member.controller.dto.request.ChangePasswordRequest;
+import com.awp.mgw.member.controller.dto.request.SavePreferencesRequest;
 import com.awp.mgw.member.domain.Member;
+import com.awp.mgw.member.domain.MemberSetting;
 import com.awp.mgw.member.domain.exception.MemberDomainException;
 import com.awp.mgw.member.domain.exception.MemberErrorCode;
 import com.awp.mgw.member.port.MemberRepository;
+import com.awp.mgw.member.port.MemberSettingRepository;
 import com.awp.mgw.member.port.RefreshTokenRepository;
 import com.awp.mgw.member.usecase.ChangePasswordUseCase;
+import com.awp.mgw.member.usecase.SavePreferencesUseCase;
 import com.awp.mgw.member.usecase.WithdrawMemberUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -18,9 +22,10 @@ import java.time.Instant;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class MemberCommandService implements ChangePasswordUseCase, WithdrawMemberUseCase {
+public class MemberCommandService implements ChangePasswordUseCase, WithdrawMemberUseCase, SavePreferencesUseCase {
 
     private final MemberRepository memberRepository;
+    private final MemberSettingRepository memberSettingRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
 
@@ -42,6 +47,21 @@ public class MemberCommandService implements ChangePasswordUseCase, WithdrawMemb
         member.detachRetainedReferences();
         member.softDelete();
         refreshTokenRepository.deleteByMemberId(memberId);
+    }
+
+    @Override
+    public void savePreferences(Long memberId, SavePreferencesRequest request) {
+        Member member = getMemberOrThrow(memberId);
+        MemberSetting setting = memberSettingRepository.findByMember_Id(memberId)
+                .orElseGet(() -> memberSettingRepository.save(
+                        MemberSetting.create(member, null)));
+
+        if (request.interestKeywords() != null) {
+            setting.updateInterestKeywords(request.interestKeywords());
+        }
+        if (request.purpose() != null) {
+            setting.updatePurpose(request.purpose());
+        }
     }
 
     private Member getMemberOrThrow(Long memberId) {

--- a/src/main/java/com/awp/mgw/member/service/MemberCommandService.java
+++ b/src/main/java/com/awp/mgw/member/service/MemberCommandService.java
@@ -1,0 +1,51 @@
+package com.awp.mgw.member.service;
+
+import com.awp.mgw.member.controller.dto.request.ChangePasswordRequest;
+import com.awp.mgw.member.domain.Member;
+import com.awp.mgw.member.domain.exception.MemberDomainException;
+import com.awp.mgw.member.domain.exception.MemberErrorCode;
+import com.awp.mgw.member.port.MemberRepository;
+import com.awp.mgw.member.port.RefreshTokenRepository;
+import com.awp.mgw.member.usecase.ChangePasswordUseCase;
+import com.awp.mgw.member.usecase.WithdrawMemberUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberCommandService implements ChangePasswordUseCase, WithdrawMemberUseCase {
+
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void changePassword(Long memberId, ChangePasswordRequest request) {
+        Member member = getMemberOrThrow(memberId);
+
+        if (!passwordEncoder.matches(request.currentPassword(), member.getPassword())) {
+            throw new MemberDomainException(MemberErrorCode.INVALID_CURRENT_PASSWORD);
+        }
+
+        member.updatePassword(passwordEncoder.encode(request.newPassword()));
+    }
+
+    @Override
+    public void withdraw(Long memberId) {
+        Member member = getMemberOrThrow(memberId);
+
+        member.detachRetainedReferences();
+        member.softDelete();
+        refreshTokenRepository.deleteByMemberId(memberId);
+    }
+
+    private Member getMemberOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberDomainException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/awp/mgw/member/usecase/ChangePasswordUseCase.java
+++ b/src/main/java/com/awp/mgw/member/usecase/ChangePasswordUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.member.usecase;
+
+import com.awp.mgw.member.controller.dto.request.ChangePasswordRequest;
+
+public interface ChangePasswordUseCase {
+    void changePassword(Long memberId, ChangePasswordRequest request);
+}

--- a/src/main/java/com/awp/mgw/member/usecase/SavePreferencesUseCase.java
+++ b/src/main/java/com/awp/mgw/member/usecase/SavePreferencesUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.member.usecase;
+
+import com.awp.mgw.member.controller.dto.request.SavePreferencesRequest;
+
+public interface SavePreferencesUseCase {
+    void savePreferences(Long memberId, SavePreferencesRequest request);
+}

--- a/src/main/java/com/awp/mgw/member/usecase/WithdrawMemberUseCase.java
+++ b/src/main/java/com/awp/mgw/member/usecase/WithdrawMemberUseCase.java
@@ -1,0 +1,5 @@
+package com.awp.mgw.member.usecase;
+
+public interface WithdrawMemberUseCase {
+    void withdraw(Long memberId);
+}

--- a/src/main/java/com/awp/mgw/mypage/controller/MyPageController.java
+++ b/src/main/java/com/awp/mgw/mypage/controller/MyPageController.java
@@ -1,12 +1,14 @@
 package com.awp.mgw.mypage.controller;
 
+import com.awp.mgw.mypage.controller.dto.request.*;
 import com.awp.mgw.mypage.controller.dto.response.MyPageMainResponse;
+import com.awp.mgw.mypage.controller.dto.response.MyPageSettingsResponse;
+import com.awp.mgw.mypage.usecase.command.*;
 import com.awp.mgw.mypage.usecase.query.GetMyPageMainUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import org.springframework.validation.annotation.Validated;
@@ -20,24 +22,68 @@ import java.time.YearMonth;
 public class MyPageController {
 
   private final GetMyPageMainUseCase getMyPageMainUseCase;
+  private final UpdateMyPageProfileUseCase updateMyPageProfileUseCase;
+  private final GetMyPageSettingsUseCase getMyPageSettingsUseCase;
+  private final UpdateMatchingCommunicationUseCase updateMatchingCommunicationUseCase;
+  private final UpdateNotificationSettingsUseCase updateNotificationSettingsUseCase;
+  private final UpdateAppLanguageUseCase updateAppLanguageUseCase;
+  private final UpdateDarkModeUseCase updateDarkModeUseCase;
 
   @GetMapping("/api/v1/mypage")
   public MyPageMainResponse getMyPageMain(
         @AuthenticationPrincipal Long memberId,
-
         @Min(value = 2000, message = "연도는 2000년 이상이어야 합니다.")
         @RequestParam int year,
-
         @Min(value = 1, message = "월은 1 이상이어야 합니다.")
         @Max(value = 12, message = "월은 12 이하여야 합니다.")
         @RequestParam int month,
-
         @RequestParam(required = false) LocalDate selectedDate
   ) {
-    return getMyPageMainUseCase.getMyPageMain(
-          memberId,
-          YearMonth.of(year, month),
-          selectedDate
-    );
+    return getMyPageMainUseCase.getMyPageMain(memberId, YearMonth.of(year, month), selectedDate);
+  }
+
+  @PatchMapping("/api/v1/mypage/profile")
+  public void updateProfile(
+        @AuthenticationPrincipal Long memberId,
+        @Valid @RequestBody UpdateProfileRequest request
+  ) {
+    updateMyPageProfileUseCase.updateProfile(memberId, request);
+  }
+
+  @GetMapping("/api/v1/mypage/settings")
+  public MyPageSettingsResponse getSettings(@AuthenticationPrincipal Long memberId) {
+    return getMyPageSettingsUseCase.getSettings(memberId);
+  }
+
+  @PatchMapping("/api/v1/mypage/settings/matching-communication")
+  public void updateMatchingCommunication(
+        @AuthenticationPrincipal Long memberId,
+        @Valid @RequestBody UpdateMatchingCommunicationRequest request
+  ) {
+    updateMatchingCommunicationUseCase.updateMatchingCommunication(memberId, request);
+  }
+
+  @PatchMapping("/api/v1/mypage/settings/notifications")
+  public void updateNotificationSettings(
+        @AuthenticationPrincipal Long memberId,
+        @Valid @RequestBody UpdateNotificationSettingsRequest request
+  ) {
+    updateNotificationSettingsUseCase.updateNotificationSettings(memberId, request);
+  }
+
+  @PatchMapping("/api/v1/mypage/settings/app-language")
+  public void updateAppLanguage(
+        @AuthenticationPrincipal Long memberId,
+        @Valid @RequestBody UpdateAppLanguageRequest request
+  ) {
+    updateAppLanguageUseCase.updateAppLanguage(memberId, request);
+  }
+
+  @PatchMapping("/api/v1/mypage/settings/dark-mode")
+  public void updateDarkMode(
+        @AuthenticationPrincipal Long memberId,
+        @Valid @RequestBody UpdateDarkModeRequest request
+  ) {
+    updateDarkModeUseCase.updateDarkMode(memberId, request);
   }
 }

--- a/src/main/java/com/awp/mgw/mypage/controller/dto/request/UpdateAppLanguageRequest.java
+++ b/src/main/java/com/awp/mgw/mypage/controller/dto/request/UpdateAppLanguageRequest.java
@@ -1,0 +1,9 @@
+package com.awp.mgw.mypage.controller.dto.request;
+
+import com.awp.mgw.member.domain.enums.Language;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateAppLanguageRequest(
+        @NotNull Language appLanguage
+) {
+}

--- a/src/main/java/com/awp/mgw/mypage/controller/dto/request/UpdateDarkModeRequest.java
+++ b/src/main/java/com/awp/mgw/mypage/controller/dto/request/UpdateDarkModeRequest.java
@@ -1,0 +1,8 @@
+package com.awp.mgw.mypage.controller.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateDarkModeRequest(
+        @NotNull Boolean darkMode
+) {
+}

--- a/src/main/java/com/awp/mgw/mypage/controller/dto/request/UpdateMatchingCommunicationRequest.java
+++ b/src/main/java/com/awp/mgw/mypage/controller/dto/request/UpdateMatchingCommunicationRequest.java
@@ -1,0 +1,11 @@
+package com.awp.mgw.mypage.controller.dto.request;
+
+import com.awp.mgw.member.domain.enums.Language;
+
+import java.util.List;
+
+public record UpdateMatchingCommunicationRequest(
+        List<String> interestKeywords,
+        Language preferredLanguage
+) {
+}

--- a/src/main/java/com/awp/mgw/mypage/controller/dto/request/UpdateNotificationSettingsRequest.java
+++ b/src/main/java/com/awp/mgw/mypage/controller/dto/request/UpdateNotificationSettingsRequest.java
@@ -1,0 +1,8 @@
+package com.awp.mgw.mypage.controller.dto.request;
+
+public record UpdateNotificationSettingsRequest(
+        Boolean messageNotification,
+        Boolean groupInviteNotification,
+        Boolean postCommentNotification
+) {
+}

--- a/src/main/java/com/awp/mgw/mypage/controller/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/awp/mgw/mypage/controller/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.mypage.controller.dto.request;
+
+public record UpdateProfileRequest(
+        String name,
+        String profileImageUrl
+) {
+}

--- a/src/main/java/com/awp/mgw/mypage/controller/dto/response/MyPageSettingsResponse.java
+++ b/src/main/java/com/awp/mgw/mypage/controller/dto/response/MyPageSettingsResponse.java
@@ -1,0 +1,58 @@
+package com.awp.mgw.mypage.controller.dto.response;
+
+import com.awp.mgw.member.domain.Member;
+import com.awp.mgw.member.domain.MemberSetting;
+import com.awp.mgw.member.domain.enums.Language;
+
+public record MyPageSettingsResponse(
+        Profile profile,
+        MatchingCommunication matchingCommunication,
+        Notifications notifications,
+        LanguageRegion languageRegion,
+        AccountSecurity accountSecurity,
+        System system
+) {
+    public static MyPageSettingsResponse from(Member member, MemberSetting setting) {
+        return new MyPageSettingsResponse(
+                new Profile(
+                        member.getName(),
+                        member.getImageUrl(),
+                        setting != null ? setting.getLanguage() : Language.en,
+                        setting != null ? setting.getDarkMode() : false,
+                        setting != null ? setting.getMessageNotification() : true,
+                        setting != null ? setting.getGroupInviteNotification() : true,
+                        setting != null ? setting.getPostCommentNotification() : true
+                ),
+                new MatchingCommunication(
+                        setting != null ? setting.getLanguage() : Language.en
+                ),
+                new Notifications(
+                        setting != null ? setting.getMessageNotification() : true,
+                        setting != null ? setting.getGroupInviteNotification() : true,
+                        setting != null ? setting.getPostCommentNotification() : true
+                ),
+                new LanguageRegion(
+                        setting != null ? setting.getLanguage() : Language.en
+                ),
+                new AccountSecurity(
+                        member.getEmail()
+                ),
+                new System(
+                        setting != null ? setting.getDarkMode() : false
+                )
+        );
+    }
+
+    public record Profile(String name, String profileImageUrl, Language language, Boolean darkMode,
+                          Boolean messageNotification, Boolean groupInviteNotification, Boolean postCommentNotification) {}
+
+    public record MatchingCommunication(Language preferredLanguage) {}
+
+    public record Notifications(Boolean newMessages, Boolean groupInvites, Boolean postComments) {}
+
+    public record LanguageRegion(Language appLanguage) {}
+
+    public record AccountSecurity(String email) {}
+
+    public record System(Boolean darkMode) {}
+}

--- a/src/main/java/com/awp/mgw/mypage/service/MyPageCommandService.java
+++ b/src/main/java/com/awp/mgw/mypage/service/MyPageCommandService.java
@@ -1,0 +1,89 @@
+package com.awp.mgw.mypage.service;
+
+import com.awp.mgw.member.domain.Member;
+import com.awp.mgw.member.domain.MemberSetting;
+import com.awp.mgw.member.domain.enums.Language;
+import com.awp.mgw.member.domain.exception.MemberDomainException;
+import com.awp.mgw.member.domain.exception.MemberErrorCode;
+import com.awp.mgw.member.port.MemberRepository;
+import com.awp.mgw.member.port.MemberSettingRepository;
+import com.awp.mgw.mypage.controller.dto.request.*;
+import com.awp.mgw.mypage.controller.dto.response.MyPageSettingsResponse;
+import com.awp.mgw.mypage.usecase.command.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MyPageCommandService implements
+        UpdateMyPageProfileUseCase,
+        GetMyPageSettingsUseCase,
+        UpdateMatchingCommunicationUseCase,
+        UpdateNotificationSettingsUseCase,
+        UpdateAppLanguageUseCase,
+        UpdateDarkModeUseCase {
+
+    private final MemberRepository memberRepository;
+    private final MemberSettingRepository memberSettingRepository;
+
+    @Override
+    public void updateProfile(Long memberId, UpdateProfileRequest request) {
+        Member member = getMemberOrThrow(memberId);
+        member.updateProfile(request.name(), request.profileImageUrl());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MyPageSettingsResponse getSettings(Long memberId) {
+        Member member = getMemberOrThrow(memberId);
+        MemberSetting setting = memberSettingRepository.findByMember_Id(memberId).orElse(null);
+        return MyPageSettingsResponse.from(member, setting);
+    }
+
+    @Override
+    public void updateMatchingCommunication(Long memberId, UpdateMatchingCommunicationRequest request) {
+        MemberSetting setting = getOrCreateSetting(memberId);
+        if (request.preferredLanguage() != null) {
+            setting.updateLanguage(request.preferredLanguage());
+        }
+        // TODO: interestKeywords 저장 — MemberSetting에 interestKeywords 필드 추가 후 구현
+    }
+
+    @Override
+    public void updateNotificationSettings(Long memberId, UpdateNotificationSettingsRequest request) {
+        MemberSetting setting = getOrCreateSetting(memberId);
+        setting.updateNotifications(
+                request.messageNotification(),
+                request.groupInviteNotification(),
+                request.postCommentNotification()
+        );
+    }
+
+    @Override
+    public void updateAppLanguage(Long memberId, UpdateAppLanguageRequest request) {
+        MemberSetting setting = getOrCreateSetting(memberId);
+        setting.updateLanguage(request.appLanguage());
+    }
+
+    @Override
+    public void updateDarkMode(Long memberId, UpdateDarkModeRequest request) {
+        MemberSetting setting = getOrCreateSetting(memberId);
+        setting.updateDarkMode(request.darkMode());
+    }
+
+    private Member getMemberOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberDomainException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private MemberSetting getOrCreateSetting(Long memberId) {
+        Member member = getMemberOrThrow(memberId);
+        return memberSettingRepository.findByMember_Id(memberId)
+                .orElseGet(() -> {
+                    MemberSetting newSetting = MemberSetting.create(member, Language.en);
+                    return memberSettingRepository.save(newSetting);
+                });
+    }
+}

--- a/src/main/java/com/awp/mgw/mypage/usecase/command/GetMyPageSettingsUseCase.java
+++ b/src/main/java/com/awp/mgw/mypage/usecase/command/GetMyPageSettingsUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.mypage.usecase.command;
+
+import com.awp.mgw.mypage.controller.dto.response.MyPageSettingsResponse;
+
+public interface GetMyPageSettingsUseCase {
+    MyPageSettingsResponse getSettings(Long memberId);
+}

--- a/src/main/java/com/awp/mgw/mypage/usecase/command/UpdateAppLanguageUseCase.java
+++ b/src/main/java/com/awp/mgw/mypage/usecase/command/UpdateAppLanguageUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.mypage.usecase.command;
+
+import com.awp.mgw.mypage.controller.dto.request.UpdateAppLanguageRequest;
+
+public interface UpdateAppLanguageUseCase {
+    void updateAppLanguage(Long memberId, UpdateAppLanguageRequest request);
+}

--- a/src/main/java/com/awp/mgw/mypage/usecase/command/UpdateDarkModeUseCase.java
+++ b/src/main/java/com/awp/mgw/mypage/usecase/command/UpdateDarkModeUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.mypage.usecase.command;
+
+import com.awp.mgw.mypage.controller.dto.request.UpdateDarkModeRequest;
+
+public interface UpdateDarkModeUseCase {
+    void updateDarkMode(Long memberId, UpdateDarkModeRequest request);
+}

--- a/src/main/java/com/awp/mgw/mypage/usecase/command/UpdateMatchingCommunicationUseCase.java
+++ b/src/main/java/com/awp/mgw/mypage/usecase/command/UpdateMatchingCommunicationUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.mypage.usecase.command;
+
+import com.awp.mgw.mypage.controller.dto.request.UpdateMatchingCommunicationRequest;
+
+public interface UpdateMatchingCommunicationUseCase {
+    void updateMatchingCommunication(Long memberId, UpdateMatchingCommunicationRequest request);
+}

--- a/src/main/java/com/awp/mgw/mypage/usecase/command/UpdateMyPageProfileUseCase.java
+++ b/src/main/java/com/awp/mgw/mypage/usecase/command/UpdateMyPageProfileUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.mypage.usecase.command;
+
+import com.awp.mgw.mypage.controller.dto.request.UpdateProfileRequest;
+
+public interface UpdateMyPageProfileUseCase {
+    void updateProfile(Long memberId, UpdateProfileRequest request);
+}

--- a/src/main/java/com/awp/mgw/mypage/usecase/command/UpdateNotificationSettingsUseCase.java
+++ b/src/main/java/com/awp/mgw/mypage/usecase/command/UpdateNotificationSettingsUseCase.java
@@ -1,0 +1,7 @@
+package com.awp.mgw.mypage.usecase.command;
+
+import com.awp.mgw.mypage.controller.dto.request.UpdateNotificationSettingsRequest;
+
+public interface UpdateNotificationSettingsUseCase {
+    void updateNotificationSettings(Long memberId, UpdateNotificationSettingsRequest request);
+}


### PR DESCRIPTION
## Summary
- Group 검색: name + title 동시 검색 지원 (공백 정규화 유지)
- Activity 검색: title + description 동시 검색 지원
- MyPage 프로필/설정 API 구현 (GET/PATCH)
- 댓글 CRUD API 구현
- 비밀번호 변경, 회원 탈퇴 API 구현
- 온보딩 선호도(interestKeywords, purpose) 저장 API 추가
- 그룹 상세 응답에 isMember 필드 추가
- Activity thumbnailUrl 검증 완화

## Test plan
- [v] GET /groups/search?keyword=... — title로도 검색되는지 확인
- [v] GET /activities/search?keyword=... — description으로도 검색되는지 확인
- [v] GET /mypage/settings — 정상 응답 확인
- [v] PATCH /mypage/settings/* — 각 설정 업데이트 동작 확인
- [v] `./gradlew build` 성공